### PR TITLE
feat: implement tree visualization with live node status

### DIFF
--- a/composite.go
+++ b/composite.go
@@ -29,17 +29,16 @@ func (s *Sequence) Tick(ctx context.Context) Status {
 		switch status {
 		case Running:
 			s.current = i
-			s.lastStatus = &status
+			s.lastStatus = statusPtr(status)
 			return Running
 		case Failure:
 			s.current = 0
-			s.lastStatus = &status
+			s.lastStatus = statusPtr(status)
 			return Failure
 		}
 	}
 	s.current = 0
-	st := Success
-	s.lastStatus = &st
+	s.lastStatus = statusPtr(Success)
 	return Success
 }
 
@@ -85,17 +84,16 @@ func (f *Fallback) Tick(ctx context.Context) Status {
 		switch status {
 		case Running:
 			f.current = i
-			f.lastStatus = &status
+			f.lastStatus = statusPtr(status)
 			return Running
 		case Success:
 			f.current = 0
-			f.lastStatus = &status
+			f.lastStatus = statusPtr(status)
 			return Success
 		}
 	}
 	f.current = 0
-	st := Failure
-	f.lastStatus = &st
+	f.lastStatus = statusPtr(Failure)
 	return Failure
 }
 

--- a/composite.go
+++ b/composite.go
@@ -7,9 +7,10 @@ import "context"
 // Returns Success when all children succeed.
 // Returns Running if a child is Running (resumes from that child on next tick).
 type Sequence struct {
-	name     string
-	children []Node
-	current  int
+	name       string
+	children   []Node
+	current    int
+	lastStatus *Status
 }
 
 // NewSequence creates a new Sequence node with the given name and child nodes.
@@ -28,14 +29,23 @@ func (s *Sequence) Tick(ctx context.Context) Status {
 		switch status {
 		case Running:
 			s.current = i
+			s.lastStatus = &status
 			return Running
 		case Failure:
 			s.current = 0
+			s.lastStatus = &status
 			return Failure
 		}
 	}
 	s.current = 0
+	st := Success
+	s.lastStatus = &st
 	return Success
+}
+
+// LastStatus returns the result of the most recent tick (implements Stateful).
+func (s *Sequence) LastStatus() *Status {
+	return s.lastStatus
 }
 
 // Children returns the child nodes of this sequence (implements Parent).
@@ -53,9 +63,10 @@ func (s *Sequence) String() string {
 // Returns Failure when all children fail.
 // Returns Running if a child is Running (resumes from that child on next tick).
 type Fallback struct {
-	name     string
-	children []Node
-	current  int
+	name       string
+	children   []Node
+	current    int
+	lastStatus *Status
 }
 
 // NewFallback creates a new Fallback node with the given name and child nodes.
@@ -74,14 +85,23 @@ func (f *Fallback) Tick(ctx context.Context) Status {
 		switch status {
 		case Running:
 			f.current = i
+			f.lastStatus = &status
 			return Running
 		case Success:
 			f.current = 0
+			f.lastStatus = &status
 			return Success
 		}
 	}
 	f.current = 0
+	st := Failure
+	f.lastStatus = &st
 	return Failure
+}
+
+// LastStatus returns the result of the most recent tick (implements Stateful).
+func (f *Fallback) LastStatus() *Status {
+	return f.lastStatus
 }
 
 // Children returns the child nodes of this fallback (implements Parent).

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	bt "github.com/ToySin/go-bt"
+)
+
+func main() {
+	batteryLevel := 80
+
+	tree := bt.NewTree(
+		bt.NewFallback("dispatch",
+			bt.NewSequence("try-assign",
+				bt.NewCondition("agent-idle", func(ctx context.Context) bool {
+					return true
+				}),
+				bt.NewCondition("battery-ok", func(ctx context.Context) bool {
+					return batteryLevel > 20
+				}),
+				bt.NewAction("assign-job", func(ctx context.Context) bt.Status {
+					return bt.Running
+				}),
+				bt.NewAction("notify-agent", func(ctx context.Context) bt.Status {
+					return bt.Success
+				}),
+			),
+			bt.NewAction("queue-job", func(ctx context.Context) bt.Status {
+				return bt.Success
+			}),
+		),
+	)
+
+	fmt.Println("=== Before tick ===")
+	bt.PrintTree(os.Stdout, tree)
+
+	fmt.Println("\n=== After tick 1 ===")
+	tree.Tick(context.Background())
+	bt.PrintTree(os.Stdout, tree)
+
+	fmt.Println("\n=== After tick 2 (job completed) ===")
+	// Simulate job completion on next tick
+	tree = bt.NewTree(
+		bt.NewFallback("dispatch",
+			bt.NewSequence("try-assign",
+				bt.NewCondition("agent-idle", func(ctx context.Context) bool {
+					return true
+				}),
+				bt.NewCondition("battery-ok", func(ctx context.Context) bool {
+					return batteryLevel > 20
+				}),
+				bt.NewAction("assign-job", func(ctx context.Context) bt.Status {
+					return bt.Success
+				}),
+				bt.NewAction("notify-agent", func(ctx context.Context) bt.Status {
+					return bt.Success
+				}),
+			),
+			bt.NewAction("queue-job", func(ctx context.Context) bt.Status {
+				return bt.Success
+			}),
+		),
+	)
+	tree.Tick(context.Background())
+	bt.PrintTree(os.Stdout, tree)
+
+	fmt.Println("\n=== Low battery scenario ===")
+	batteryLevel = 10
+	tree = bt.NewTree(
+		bt.NewFallback("dispatch",
+			bt.NewSequence("try-assign",
+				bt.NewCondition("agent-idle", func(ctx context.Context) bool {
+					return true
+				}),
+				bt.NewCondition("battery-ok", func(ctx context.Context) bool {
+					return batteryLevel > 20
+				}),
+				bt.NewAction("assign-job", func(ctx context.Context) bt.Status {
+					return bt.Success
+				}),
+				bt.NewAction("notify-agent", func(ctx context.Context) bt.Status {
+					return bt.Success
+				}),
+			),
+			bt.NewAction("queue-job", func(ctx context.Context) bt.Status {
+				fmt.Println("  >> Job queued (no suitable agent)")
+				return bt.Success
+			}),
+		),
+	)
+	tree.Tick(context.Background())
+	bt.PrintTree(os.Stdout, tree)
+}

--- a/leaf.go
+++ b/leaf.go
@@ -13,8 +13,9 @@ type ActionFunc func(ctx context.Context) Status
 
 // Action is a leaf node that executes a user-provided function.
 type Action struct {
-	name string
-	fn   ActionFunc
+	name       string
+	fn         ActionFunc
+	lastStatus *Status
 }
 
 // NewAction creates a new Action node with the given name and function.
@@ -27,12 +28,19 @@ func NewAction(name string, fn ActionFunc) *Action {
 
 // Tick executes the action's function and returns its status.
 func (a *Action) Tick(ctx context.Context) Status {
-	return a.fn(ctx)
+	status := a.fn(ctx)
+	a.lastStatus = &status
+	return status
 }
 
 // String returns the name of the action (implements fmt.Stringer).
 func (a *Action) String() string {
 	return a.name
+}
+
+// LastStatus returns the result of the most recent tick (implements Stateful).
+func (a *Action) LastStatus() *Status {
+	return a.lastStatus
 }
 
 // ConditionFunc is a predicate that evaluates to true or false.
@@ -41,8 +49,9 @@ type ConditionFunc func(ctx context.Context) bool
 // Condition is a leaf node that evaluates a predicate.
 // Returns Success if true, Failure if false. Never returns Running.
 type Condition struct {
-	name string
-	fn   ConditionFunc
+	name       string
+	fn         ConditionFunc
+	lastStatus *Status
 }
 
 // NewCondition creates a new Condition node with the given name
@@ -57,13 +66,22 @@ func NewCondition(name string, fn ConditionFunc) *Condition {
 // Tick evaluates the condition's predicate and returns Success if true,
 // Failure if false. Never returns Running.
 func (c *Condition) Tick(ctx context.Context) Status {
+	var status Status
 	if c.fn(ctx) {
-		return Success
+		status = Success
+	} else {
+		status = Failure
 	}
-	return Failure
+	c.lastStatus = &status
+	return status
 }
 
 // String returns the name of the condition (implements fmt.Stringer).
 func (c *Condition) String() string {
 	return c.name
+}
+
+// LastStatus returns the result of the most recent tick (implements Stateful).
+func (c *Condition) LastStatus() *Status {
+	return c.lastStatus
 }

--- a/leaf.go
+++ b/leaf.go
@@ -29,7 +29,7 @@ func NewAction(name string, fn ActionFunc) *Action {
 // Tick executes the action's function and returns its status.
 func (a *Action) Tick(ctx context.Context) Status {
 	status := a.fn(ctx)
-	a.lastStatus = &status
+	a.lastStatus = statusPtr(status)
 	return status
 }
 
@@ -66,13 +66,11 @@ func NewCondition(name string, fn ConditionFunc) *Condition {
 // Tick evaluates the condition's predicate and returns Success if true,
 // Failure if false. Never returns Running.
 func (c *Condition) Tick(ctx context.Context) Status {
-	var status Status
+	status := Failure
 	if c.fn(ctx) {
 		status = Success
-	} else {
-		status = Failure
 	}
-	c.lastStatus = &status
+	c.lastStatus = statusPtr(status)
 	return status
 }
 

--- a/node.go
+++ b/node.go
@@ -53,3 +53,7 @@ type Stateful interface {
 	// or nil if the node has not been ticked yet.
 	LastStatus() *Status
 }
+
+func statusPtr(s Status) *Status {
+	return &s
+}

--- a/node.go
+++ b/node.go
@@ -45,3 +45,11 @@ type Parent interface {
 	// Children returns the child nodes of this parent node.
 	Children() []Node
 }
+
+// Stateful is implemented by nodes that track their last tick result.
+// Used by the visualization system to display node status.
+type Stateful interface {
+	// LastStatus returns the result of the most recent tick,
+	// or nil if the node has not been ticked yet.
+	LastStatus() *Status
+}

--- a/visualize.go
+++ b/visualize.go
@@ -1,0 +1,96 @@
+package bt
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+func statusSymbol(s *Status) string {
+	if s == nil {
+		return "[ ]"
+	}
+	switch *s {
+	case Success:
+		return "[✓]"
+	case Failure:
+		return "[✗]"
+	case Running:
+		return "[~]"
+	default:
+		return "[?]"
+	}
+}
+
+func statusLabel(s *Status) string {
+	if s == nil {
+		return "-"
+	}
+	return s.String()
+}
+
+func nodeType(n Node) string {
+	switch n.(type) {
+	case *Sequence:
+		return "Sequence"
+	case *Fallback:
+		return "Fallback"
+	case *Action:
+		return "Action"
+	case *Condition:
+		return "Condition"
+	default:
+		return "Node"
+	}
+}
+
+// PrintTree writes a visual representation of the tree to the given writer.
+// Each node shows its type, name, and last tick status.
+func PrintTree(w io.Writer, tree *Tree) {
+	printNode(w, tree.Root(), "", true, true)
+}
+
+func printNode(w io.Writer, node Node, prefix string, isLast bool, isRoot bool) {
+	var connector string
+	if isRoot {
+		connector = ""
+	} else if isLast {
+		connector = "└── "
+	} else {
+		connector = "├── "
+	}
+
+	var status *Status
+	if s, ok := node.(Stateful); ok {
+		status = s.LastStatus()
+	}
+
+	line := fmt.Sprintf("%s%s%s %s: %s (%s)\n",
+		prefix, connector, statusSymbol(status),
+		nodeType(node), node.String(), statusLabel(status),
+	)
+	fmt.Fprint(w, line)
+
+	if p, ok := node.(Parent); ok {
+		children := p.Children()
+		childPrefix := prefix
+		if !isRoot {
+			if isLast {
+				childPrefix = prefix + "    "
+			} else {
+				childPrefix = prefix + "│   "
+			}
+		}
+
+		for i, child := range children {
+			printNode(w, child, childPrefix, i == len(children)-1, false)
+		}
+	}
+}
+
+// SprintTree returns a string representation of the tree.
+func SprintTree(tree *Tree) string {
+	var sb strings.Builder
+	PrintTree(&sb, tree)
+	return sb.String()
+}

--- a/visualize_test.go
+++ b/visualize_test.go
@@ -1,0 +1,101 @@
+package bt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	bt "github.com/ToySin/go-bt"
+)
+
+func TestPrintTree_BeforeTick(t *testing.T) {
+	tree := bt.NewTree(
+		bt.NewSequence("root",
+			bt.NewCondition("check", func(ctx context.Context) bool {
+				return true
+			}),
+			bt.NewAction("work", func(ctx context.Context) bt.Status {
+				return bt.Success
+			}),
+		),
+	)
+
+	output := bt.SprintTree(tree)
+
+	assert.Contains(t, output, "Sequence: root (-)")
+	assert.Contains(t, output, "Condition: check (-)")
+	assert.Contains(t, output, "Action: work (-)")
+	assert.Contains(t, output, "[ ]")
+}
+
+func TestPrintTree_AfterTick(t *testing.T) {
+	tree := bt.NewTree(
+		bt.NewSequence("root",
+			bt.NewCondition("check", func(ctx context.Context) bool {
+				return true
+			}),
+			bt.NewAction("work", func(ctx context.Context) bt.Status {
+				return bt.Success
+			}),
+		),
+	)
+
+	tree.Tick(context.Background())
+	output := bt.SprintTree(tree)
+
+	assert.Contains(t, output, "[✓] Sequence: root (Success)")
+	assert.Contains(t, output, "[✓] Condition: check (Success)")
+	assert.Contains(t, output, "[✓] Action: work (Success)")
+}
+
+func TestPrintTree_Running(t *testing.T) {
+	tree := bt.NewTree(
+		bt.NewSequence("dispatch",
+			bt.NewCondition("agent-idle", func(ctx context.Context) bool {
+				return true
+			}),
+			bt.NewAction("assign-job", func(ctx context.Context) bt.Status {
+				return bt.Running
+			}),
+			bt.NewAction("notify", func(ctx context.Context) bt.Status {
+				return bt.Success
+			}),
+		),
+	)
+
+	tree.Tick(context.Background())
+	output := bt.SprintTree(tree)
+
+	assert.Contains(t, output, "[~] Sequence: dispatch (Running)")
+	assert.Contains(t, output, "[✓] Condition: agent-idle (Success)")
+	assert.Contains(t, output, "[~] Action: assign-job (Running)")
+	assert.Contains(t, output, "[ ] Action: notify (-)")
+}
+
+func TestPrintTree_NestedFallback(t *testing.T) {
+	tree := bt.NewTree(
+		bt.NewFallback("root",
+			bt.NewSequence("branch-1",
+				bt.NewCondition("guard", func(ctx context.Context) bool {
+					return false
+				}),
+				bt.NewAction("unreachable", func(ctx context.Context) bt.Status {
+					return bt.Success
+				}),
+			),
+			bt.NewAction("fallback-action", func(ctx context.Context) bt.Status {
+				return bt.Success
+			}),
+		),
+	)
+
+	tree.Tick(context.Background())
+	output := bt.SprintTree(tree)
+
+	assert.Contains(t, output, "[✓] Fallback: root (Success)")
+	assert.Contains(t, output, "[✗] Sequence: branch-1 (Failure)")
+	assert.Contains(t, output, "[✗] Condition: guard (Failure)")
+	assert.Contains(t, output, "[ ] Action: unreachable (-)")
+	assert.Contains(t, output, "[✓] Action: fallback-action (Success)")
+}


### PR DESCRIPTION
Changelog
======
- Add `Stateful` interface and `lastStatus` tracking to all node types
- Implement `PrintTree` / `SprintTree` with tree connectors and live status symbols
- Add `statusPtr` helper for consistent pointer creation
- Add example demonstrating dispatch scenarios with visualization

Closes #9

Testing
======
- `go vet ./...` passes
- `go test ./...` — 15/15 PASS
- `go run ./example/` — tree visualization output verified
```donshin@Dongbins-MacBook-Air go-bt % go run ./example/
=== Before tick ===
[ ] Fallback: dispatch (-)
├── [ ] Sequence: try-assign (-)
│   ├── [ ] Condition: agent-idle (-)
│   ├── [ ] Condition: battery-ok (-)
│   ├── [ ] Action: assign-job (-)
│   └── [ ] Action: notify-agent (-)
└── [ ] Action: queue-job (-)

=== After tick 1 ===
[~] Fallback: dispatch (Running)
├── [~] Sequence: try-assign (Running)
│   ├── [✓] Condition: agent-idle (Success)
│   ├── [✓] Condition: battery-ok (Success)
│   ├── [~] Action: assign-job (Running)
│   └── [ ] Action: notify-agent (-)
└── [ ] Action: queue-job (-)

=== After tick 2 (job completed) ===
[✓] Fallback: dispatch (Success)
├── [✓] Sequence: try-assign (Success)
│   ├── [✓] Condition: agent-idle (Success)
│   ├── [✓] Condition: battery-ok (Success)
│   ├── [✓] Action: assign-job (Success)
│   └── [✓] Action: notify-agent (Success)
└── [ ] Action: queue-job (-)

=== Low battery scenario ===
  >> Job queued (no suitable agent)
[✓] Fallback: dispatch (Success)
├── [✗] Sequence: try-assign (Failure)
│   ├── [✓] Condition: agent-idle (Success)
│   ├── [✗] Condition: battery-ok (Failure)
│   ├── [ ] Action: assign-job (-)
│   └── [ ] Action: notify-agent (-)
└── [✓] Action: queue-job (Success)
```