### PR TITLE
feat: implement Decorator nodes (Inverter, Repeater, Retry, Timeout)

### DIFF
--- a/decorator.go
+++ b/decorator.go
@@ -1,0 +1,159 @@
+package arbor
+
+import (
+	"context"
+	"time"
+)
+
+// Inverter flips the child's result: Success ↔ Failure. Running passes through.
+type Inverter struct {
+	name       string
+	child      Node
+	lastStatus *Status
+}
+
+func NewInverter(name string, child Node) *Inverter {
+	return &Inverter{name: name, child: child}
+}
+
+func (inv *Inverter) Tick(ctx context.Context) Status {
+	status := inv.child.Tick(ctx)
+	switch status {
+	case Success:
+		inv.lastStatus = statusPtr(Failure)
+		return Failure
+	case Failure:
+		inv.lastStatus = statusPtr(Success)
+		return Success
+	default:
+		inv.lastStatus = statusPtr(Running)
+		return Running
+	}
+}
+
+func (inv *Inverter) Children() []Node   { return []Node{inv.child} }
+func (inv *Inverter) String() string     { return inv.name }
+func (inv *Inverter) LastStatus() *Status { return inv.lastStatus }
+
+// Repeater ticks its child N times. Succeeds when all N ticks succeed.
+// Fails immediately if the child fails.
+type Repeater struct {
+	name       string
+	child      Node
+	maxCount   int
+	current    int
+	lastStatus *Status
+}
+
+func NewRepeater(name string, n int, child Node) *Repeater {
+	return &Repeater{name: name, child: child, maxCount: n}
+}
+
+func (r *Repeater) Tick(ctx context.Context) Status {
+	status := r.child.Tick(ctx)
+	switch status {
+	case Running:
+		r.lastStatus = statusPtr(Running)
+		return Running
+	case Failure:
+		r.current = 0
+		r.lastStatus = statusPtr(Failure)
+		return Failure
+	case Success:
+		r.current++
+		if r.current >= r.maxCount {
+			r.current = 0
+			r.lastStatus = statusPtr(Success)
+			return Success
+		}
+		r.lastStatus = statusPtr(Running)
+		return Running
+	}
+	return Failure
+}
+
+func (r *Repeater) Children() []Node   { return []Node{r.child} }
+func (r *Repeater) String() string     { return r.name }
+func (r *Repeater) LastStatus() *Status { return r.lastStatus }
+
+// Retry re-ticks its child on failure, up to N attempts.
+// Succeeds immediately if the child succeeds.
+type Retry struct {
+	name       string
+	child      Node
+	maxRetries int
+	attempts   int
+	lastStatus *Status
+}
+
+func NewRetry(name string, maxRetries int, child Node) *Retry {
+	return &Retry{name: name, child: child, maxRetries: maxRetries}
+}
+
+func (r *Retry) Tick(ctx context.Context) Status {
+	status := r.child.Tick(ctx)
+	switch status {
+	case Running:
+		r.lastStatus = statusPtr(Running)
+		return Running
+	case Success:
+		r.attempts = 0
+		r.lastStatus = statusPtr(Success)
+		return Success
+	case Failure:
+		r.attempts++
+		if r.attempts >= r.maxRetries {
+			r.attempts = 0
+			r.lastStatus = statusPtr(Failure)
+			return Failure
+		}
+		r.lastStatus = statusPtr(Running)
+		return Running
+	}
+	return Failure
+}
+
+func (r *Retry) Children() []Node   { return []Node{r.child} }
+func (r *Retry) String() string     { return r.name }
+func (r *Retry) LastStatus() *Status { return r.lastStatus }
+
+// Timeout fails the child if it stays Running beyond the given duration.
+// Tracks elapsed time across ticks.
+type Timeout struct {
+	name       string
+	child      Node
+	duration   time.Duration
+	startTime  time.Time
+	running    bool
+	lastStatus *Status
+}
+
+func NewTimeout(name string, duration time.Duration, child Node) *Timeout {
+	return &Timeout{name: name, child: child, duration: duration}
+}
+
+func (t *Timeout) Tick(ctx context.Context) Status {
+	status := t.child.Tick(ctx)
+	switch status {
+	case Running:
+		if !t.running {
+			t.startTime = time.Now()
+			t.running = true
+		}
+		if time.Since(t.startTime) >= t.duration {
+			t.running = false
+			t.lastStatus = statusPtr(Failure)
+			return Failure
+		}
+		t.lastStatus = statusPtr(Running)
+		return Running
+	default:
+		t.running = false
+		t.lastStatus = statusPtr(status)
+		return status
+	}
+}
+
+func (t *Timeout) Children() []Node   { return []Node{t.child} }
+func (t *Timeout) String() string     { return t.name }
+func (t *Timeout) LastStatus() *Status { return t.lastStatus }

--- a/decorator.go
+++ b/decorator.go
@@ -12,10 +12,12 @@ type Inverter struct {
 	lastStatus *Status
 }
 
+// NewInverter creates a new Inverter node with the given name and child.
 func NewInverter(name string, child Node) *Inverter {
 	return &Inverter{name: name, child: child}
 }
 
+// Tick executes the child node and inverts its result. Running is not inverted.
 func (inv *Inverter) Tick(ctx context.Context) Status {
 	status := inv.child.Tick(ctx)
 	switch status {
@@ -31,8 +33,13 @@ func (inv *Inverter) Tick(ctx context.Context) Status {
 	}
 }
 
-func (inv *Inverter) Children() []Node   { return []Node{inv.child} }
-func (inv *Inverter) String() string     { return inv.name }
+// Children returns the child node of the Inverter.
+func (inv *Inverter) Children() []Node { return []Node{inv.child} }
+
+// String returns the name of the Inverter node.
+func (inv *Inverter) String() string { return inv.name }
+
+// LastStatus returns the last status of the Inverter node.
 func (inv *Inverter) LastStatus() *Status { return inv.lastStatus }
 
 // Repeater ticks its child N times. Succeeds when all N ticks succeed.
@@ -45,10 +52,14 @@ type Repeater struct {
 	lastStatus *Status
 }
 
+// NewRepeater creates a new Repeater node with the given name, repeater count,
+// and child node.
 func NewRepeater(name string, n int, child Node) *Repeater {
 	return &Repeater{name: name, child: child, maxCount: n}
 }
 
+// Tick executes the child node and counts successful ticks. If the child fails,
+// the count resets. The Repeater succeeds when the count reaches maxCount.
 func (r *Repeater) Tick(ctx context.Context) Status {
 	status := r.child.Tick(ctx)
 	switch status {
@@ -72,8 +83,13 @@ func (r *Repeater) Tick(ctx context.Context) Status {
 	return Failure
 }
 
-func (r *Repeater) Children() []Node   { return []Node{r.child} }
-func (r *Repeater) String() string     { return r.name }
+// Children returns the child node of the Repeater.
+func (r *Repeater) Children() []Node { return []Node{r.child} }
+
+// String returns the name of the Repeater node.
+func (r *Repeater) String() string { return r.name }
+
+// LastStatus returns the last status of the Repeater node.
 func (r *Repeater) LastStatus() *Status { return r.lastStatus }
 
 // Retry re-ticks its child on failure, up to N attempts.
@@ -86,10 +102,13 @@ type Retry struct {
 	lastStatus *Status
 }
 
+// NewRetry creates a new Retry node with the given name, max retries, and child node.
 func NewRetry(name string, maxRetries int, child Node) *Retry {
 	return &Retry{name: name, child: child, maxRetries: maxRetries}
 }
 
+// Tick executes the child node. On failure, increments the attempt counter
+// and returns Running to retry on the next tick. Fails when max retries exhausted.
 func (r *Retry) Tick(ctx context.Context) Status {
 	status := r.child.Tick(ctx)
 	switch status {
@@ -113,8 +132,13 @@ func (r *Retry) Tick(ctx context.Context) Status {
 	return Failure
 }
 
-func (r *Retry) Children() []Node   { return []Node{r.child} }
-func (r *Retry) String() string     { return r.name }
+// Children returns the child node of the Retry.
+func (r *Retry) Children() []Node { return []Node{r.child} }
+
+// String returns the name of the Retry node.
+func (r *Retry) String() string { return r.name }
+
+// LastStatus returns the last status of the Retry node.
 func (r *Retry) LastStatus() *Status { return r.lastStatus }
 
 // Timeout fails the child if it stays Running beyond the given duration.
@@ -128,10 +152,13 @@ type Timeout struct {
 	lastStatus *Status
 }
 
+// NewTimeout creates a new Timeout node with the given name, duration, and child node.
 func NewTimeout(name string, duration time.Duration, child Node) *Timeout {
 	return &Timeout{name: name, child: child, duration: duration}
 }
 
+// Tick executes the child node. If the child returns Running, starts or continues
+// tracking elapsed time. Fails if the duration is exceeded.
 func (t *Timeout) Tick(ctx context.Context) Status {
 	status := t.child.Tick(ctx)
 	switch status {
@@ -154,6 +181,11 @@ func (t *Timeout) Tick(ctx context.Context) Status {
 	}
 }
 
-func (t *Timeout) Children() []Node   { return []Node{t.child} }
-func (t *Timeout) String() string     { return t.name }
+// Children returns the child node of the Timeout.
+func (t *Timeout) Children() []Node { return []Node{t.child} }
+
+// String returns the name of the Timeout node.
+func (t *Timeout) String() string { return t.name }
+
+// LastStatus returns the last status of the Timeout node.
 func (t *Timeout) LastStatus() *Status { return t.lastStatus }

--- a/decorator_test.go
+++ b/decorator_test.go
@@ -1,0 +1,177 @@
+package arbor_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	arbor "github.com/ToySin/go-arbor"
+)
+
+// --- Inverter ---
+
+func TestInverter_FlipsSuccess(t *testing.T) {
+	inv := arbor.NewInverter("inv",
+		arbor.NewAction("ok", func(ctx context.Context) arbor.Status { return arbor.Success }),
+	)
+
+	assert.Equal(t, arbor.Failure, inv.Tick(context.Background()))
+}
+
+func TestInverter_FlipsFailure(t *testing.T) {
+	inv := arbor.NewInverter("inv",
+		arbor.NewAction("fail", func(ctx context.Context) arbor.Status { return arbor.Failure }),
+	)
+
+	assert.Equal(t, arbor.Success, inv.Tick(context.Background()))
+}
+
+func TestInverter_RunningPassesThrough(t *testing.T) {
+	inv := arbor.NewInverter("inv",
+		arbor.NewAction("busy", func(ctx context.Context) arbor.Status { return arbor.Running }),
+	)
+
+	assert.Equal(t, arbor.Running, inv.Tick(context.Background()))
+}
+
+// --- Repeater ---
+
+func TestRepeater_SucceedsAfterN(t *testing.T) {
+	count := 0
+	rep := arbor.NewRepeater("rep", 3,
+		arbor.NewAction("work", func(ctx context.Context) arbor.Status {
+			count++
+			return arbor.Success
+		}),
+	)
+
+	tree := arbor.NewTree(rep)
+
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()), "tick 1")
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()), "tick 2")
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()), "tick 3")
+	assert.Equal(t, 3, count)
+}
+
+func TestRepeater_FailsImmediately(t *testing.T) {
+	count := 0
+	rep := arbor.NewRepeater("rep", 5,
+		arbor.NewAction("flaky", func(ctx context.Context) arbor.Status {
+			count++
+			if count == 2 {
+				return arbor.Failure
+			}
+			return arbor.Success
+		}),
+	)
+
+	tree := arbor.NewTree(rep)
+
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()), "tick 1")
+	assert.Equal(t, arbor.Failure, tree.Tick(context.Background()), "tick 2")
+}
+
+func TestRepeater_WaitsForRunning(t *testing.T) {
+	tickCount := 0
+	rep := arbor.NewRepeater("rep", 2,
+		arbor.NewAction("slow", func(ctx context.Context) arbor.Status {
+			tickCount++
+			if tickCount%2 == 1 {
+				return arbor.Running
+			}
+			return arbor.Success
+		}),
+	)
+
+	tree := arbor.NewTree(rep)
+
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()), "tick 1: child Running")
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()), "tick 2: child Success, 1/2")
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()), "tick 3: child Running")
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()), "tick 4: child Success, 2/2")
+}
+
+// --- Retry ---
+
+func TestRetry_SucceedsImmediately(t *testing.T) {
+	r := arbor.NewRetry("retry", 3,
+		arbor.NewAction("ok", func(ctx context.Context) arbor.Status { return arbor.Success }),
+	)
+
+	assert.Equal(t, arbor.Success, r.Tick(context.Background()))
+}
+
+func TestRetry_RetriesOnFailure(t *testing.T) {
+	count := 0
+	r := arbor.NewRetry("retry", 3,
+		arbor.NewAction("flaky", func(ctx context.Context) arbor.Status {
+			count++
+			if count < 3 {
+				return arbor.Failure
+			}
+			return arbor.Success
+		}),
+	)
+
+	tree := arbor.NewTree(r)
+
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()), "tick 1: fail, retry")
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()), "tick 2: fail, retry")
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()), "tick 3: success")
+}
+
+func TestRetry_ExhaustsRetries(t *testing.T) {
+	r := arbor.NewRetry("retry", 2,
+		arbor.NewAction("always-fail", func(ctx context.Context) arbor.Status { return arbor.Failure }),
+	)
+
+	tree := arbor.NewTree(r)
+
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()), "tick 1")
+	assert.Equal(t, arbor.Failure, tree.Tick(context.Background()), "tick 2: exhausted")
+}
+
+// --- Timeout ---
+
+func TestTimeout_SucceedsWithinTime(t *testing.T) {
+	to := arbor.NewTimeout("timeout", 1*time.Second,
+		arbor.NewAction("fast", func(ctx context.Context) arbor.Status { return arbor.Success }),
+	)
+
+	assert.Equal(t, arbor.Success, to.Tick(context.Background()))
+}
+
+func TestTimeout_FailsAfterDuration(t *testing.T) {
+	to := arbor.NewTimeout("timeout", 1*time.Millisecond,
+		arbor.NewAction("slow", func(ctx context.Context) arbor.Status { return arbor.Running }),
+	)
+
+	tree := arbor.NewTree(to)
+
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()), "tick 1: started")
+	time.Sleep(2 * time.Millisecond)
+	assert.Equal(t, arbor.Failure, tree.Tick(context.Background()), "tick 2: timed out")
+}
+
+// --- Visualization ---
+
+func TestDecorator_Visualization(t *testing.T) {
+	tree := arbor.NewTree(
+		arbor.NewRetry("retry-connect", 3,
+			arbor.NewInverter("not-blocked",
+				arbor.NewCondition("is-blocked", func(ctx context.Context) bool {
+					return true
+				}),
+			),
+		),
+	)
+
+	tree.Tick(context.Background())
+	output := arbor.SprintTree(tree)
+
+	assert.Contains(t, output, "Retry: retry-connect")
+	assert.Contains(t, output, "Inverter: not-blocked")
+	assert.Contains(t, output, "Condition: is-blocked")
+}

--- a/visualize.go
+++ b/visualize.go
@@ -37,6 +37,14 @@ func nodeType(n Node) string {
 		return "Fallback"
 	case *Parallel:
 		return "Parallel"
+	case *Inverter:
+		return "Inverter"
+	case *Repeater:
+		return "Repeater"
+	case *Retry:
+		return "Retry"
+	case *Timeout:
+		return "Timeout"
 	case *Action:
 		return "Action"
 	case *Condition:


### PR DESCRIPTION
Changelog
======
- Implement Inverter — flips Success ↔ Failure, Running passes through
- Implement Repeater — ticks child N times, fails immediately on child failure
- Implement Retry — re-ticks child on failure up to N attempts
- Implement Timeout — fails child if Running beyond given duration
- Add decorator types to tree visualization

Closes #6

Testing
======
- `go vet ./...` passes
- `go test ./...` — all PASS