### PR TITLE
feat: implement Blackboard with context injection and generic getter

### DIFF
--- a/blackboard.go
+++ b/blackboard.go
@@ -1,0 +1,72 @@
+package arbor
+
+import "context"
+
+type contextKey string
+
+const blackboardKey contextKey = "arbor.blackboard"
+
+// Blackboard is a shared key-value store for passing data between nodes.
+type Blackboard struct {
+	data map[string]any
+}
+
+// NewBlackboard creates a new empty Blackboard.
+func NewBlackboard() *Blackboard {
+	return &Blackboard{data: make(map[string]any)}
+}
+
+// Set stores a value under the given key.
+func (bb *Blackboard) Set(key string, value any) {
+	bb.data[key] = value
+}
+
+// Get retrieves a value by key. Returns the value and whether the key exists.
+func (bb *Blackboard) Get(key string) (any, bool) {
+	v, ok := bb.data[key]
+	return v, ok
+}
+
+// Delete removes a key from the blackboard.
+func (bb *Blackboard) Delete(key string) {
+	delete(bb.data, key)
+}
+
+// Has returns whether the given key exists.
+func (bb *Blackboard) Has(key string) bool {
+	_, ok := bb.data[key]
+	return ok
+}
+
+// Clear removes all entries from the blackboard.
+func (bb *Blackboard) Clear() {
+	clear(bb.data)
+}
+
+// GetTyped retrieves a value by key with type assertion.
+// Returns the zero value and false if the key doesn't exist or the type doesn't match.
+func GetTyped[T any](bb *Blackboard, key string) (T, bool) {
+	v, ok := bb.data[key]
+	if !ok {
+		var zero T
+		return zero, false
+	}
+	typed, ok := v.(T)
+	if !ok {
+		var zero T
+		return zero, false
+	}
+	return typed, true
+}
+
+// WithBlackboard returns a new context with the given Blackboard attached.
+func WithBlackboard(ctx context.Context, bb *Blackboard) context.Context {
+	return context.WithValue(ctx, blackboardKey, bb)
+}
+
+// BlackboardFrom retrieves the Blackboard from the context.
+// Returns nil if no Blackboard is attached.
+func BlackboardFrom(ctx context.Context) *Blackboard {
+	bb, _ := ctx.Value(blackboardKey).(*Blackboard)
+	return bb
+}

--- a/blackboard_test.go
+++ b/blackboard_test.go
@@ -1,0 +1,156 @@
+package arbor_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	arbor "github.com/ToySin/go-arbor"
+)
+
+func TestBlackboard_SetAndGet(t *testing.T) {
+	bb := arbor.NewBlackboard()
+	bb.Set("key", "value")
+
+	v, ok := bb.Get("key")
+
+	assert.True(t, ok)
+	assert.Equal(t, "value", v)
+}
+
+func TestBlackboard_GetMissing(t *testing.T) {
+	bb := arbor.NewBlackboard()
+
+	v, ok := bb.Get("missing")
+
+	assert.False(t, ok)
+	assert.Nil(t, v)
+}
+
+func TestBlackboard_Delete(t *testing.T) {
+	bb := arbor.NewBlackboard()
+	bb.Set("key", "value")
+	bb.Delete("key")
+
+	assert.False(t, bb.Has("key"))
+}
+
+func TestBlackboard_Has(t *testing.T) {
+	bb := arbor.NewBlackboard()
+
+	assert.False(t, bb.Has("key"))
+	bb.Set("key", 42)
+	assert.True(t, bb.Has("key"))
+}
+
+func TestBlackboard_Clear(t *testing.T) {
+	bb := arbor.NewBlackboard()
+	bb.Set("a", 1)
+	bb.Set("b", 2)
+	bb.Clear()
+
+	assert.False(t, bb.Has("a"))
+	assert.False(t, bb.Has("b"))
+}
+
+func TestGetTyped(t *testing.T) {
+	bb := arbor.NewBlackboard()
+	bb.Set("count", 42)
+	bb.Set("name", "agent-1")
+
+	count, ok := arbor.GetTyped[int](bb, "count")
+	assert.True(t, ok)
+	assert.Equal(t, 42, count)
+
+	name, ok := arbor.GetTyped[string](bb, "name")
+	assert.True(t, ok)
+	assert.Equal(t, "agent-1", name)
+}
+
+func TestGetTyped_WrongType(t *testing.T) {
+	bb := arbor.NewBlackboard()
+	bb.Set("count", "not-an-int")
+
+	v, ok := arbor.GetTyped[int](bb, "count")
+	assert.False(t, ok)
+	assert.Equal(t, 0, v)
+}
+
+func TestGetTyped_Missing(t *testing.T) {
+	bb := arbor.NewBlackboard()
+
+	v, ok := arbor.GetTyped[string](bb, "missing")
+	assert.False(t, ok)
+	assert.Equal(t, "", v)
+}
+
+func TestBlackboard_FromContext(t *testing.T) {
+	bb := arbor.NewBlackboard()
+	bb.Set("key", "value")
+
+	ctx := arbor.WithBlackboard(context.Background(), bb)
+	retrieved := arbor.BlackboardFrom(ctx)
+
+	assert.NotNil(t, retrieved)
+	v, ok := retrieved.Get("key")
+	assert.True(t, ok)
+	assert.Equal(t, "value", v)
+}
+
+func TestBlackboard_FromContext_Nil(t *testing.T) {
+	bb := arbor.BlackboardFrom(context.Background())
+
+	assert.Nil(t, bb)
+}
+
+func TestBlackboard_TreeIntegration(t *testing.T) {
+	tree := arbor.NewTree(
+		arbor.NewSequence("pipeline",
+			arbor.NewAction("produce", func(ctx context.Context) arbor.Status {
+				bb := arbor.BlackboardFrom(ctx)
+				bb.Set("target", "agent-7")
+				return arbor.Success
+			}),
+			arbor.NewAction("consume", func(ctx context.Context) arbor.Status {
+				bb := arbor.BlackboardFrom(ctx)
+				target, ok := arbor.GetTyped[string](bb, "target")
+				if !ok || target != "agent-7" {
+					return arbor.Failure
+				}
+				return arbor.Success
+			}),
+		),
+	)
+
+	status := tree.Tick(context.Background())
+
+	assert.Equal(t, arbor.Success, status)
+}
+
+func TestBlackboard_PersistsAcrossTicks(t *testing.T) {
+	tickCount := 0
+	tree := arbor.NewTree(
+		arbor.NewSequence("multi-tick",
+			arbor.NewAction("write-once", func(ctx context.Context) arbor.Status {
+				bb := arbor.BlackboardFrom(ctx)
+				tickCount++
+				if tickCount == 1 {
+					bb.Set("data", "persisted")
+				}
+				return arbor.Success
+			}),
+			arbor.NewAction("read-always", func(ctx context.Context) arbor.Status {
+				bb := arbor.BlackboardFrom(ctx)
+				v, ok := arbor.GetTyped[string](bb, "data")
+				if !ok || v != "persisted" {
+					return arbor.Failure
+				}
+				return arbor.Success
+			}),
+		),
+	)
+
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()), "tick 1: write and read")
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()), "tick 2: data persists")
+}

--- a/tree.go
+++ b/tree.go
@@ -4,17 +4,29 @@ import "context"
 
 // Tree is the top-level container that drives tick execution from the root node.
 type Tree struct {
-	root Node
+	root       Node
+	blackboard *Blackboard
 }
 
 // NewTree creates a new behavior tree with the given root node.
+// A Blackboard is automatically created and injected into the context on each tick.
 func NewTree(root Node) *Tree {
-	return &Tree{root: root}
+	return &Tree{
+		root:       root,
+		blackboard: NewBlackboard(),
+	}
 }
 
 // Tick executes a single tick starting from the root node.
+// The tree's Blackboard is injected into the context automatically.
 func (t *Tree) Tick(ctx context.Context) Status {
+	ctx = WithBlackboard(ctx, t.blackboard)
 	return t.root.Tick(ctx)
+}
+
+// Blackboard returns the tree's shared Blackboard.
+func (t *Tree) Blackboard() *Blackboard {
+	return t.blackboard
 }
 
 // Root returns the root node of the tree.


### PR DESCRIPTION
Changelog
======
- Implement `Blackboard` — shared key-value store for inter-node data passing
- `GetTyped[T]` generic helper for type-safe retrieval
- Context-based injection — `WithBlackboard` / `BlackboardFrom`
- `Tree` automatically creates and injects Blackboard on each tick
- `Tree.Blackboard()` accessor for external access

Closes #7

Testing
======
- `go vet ./...` passes
- `go test ./...` — all PASS
- 12 Blackboard tests: CRUD, generic getter, context injection, tree integration, cross-tick persistence