### PR TITLE
feat: implement tick runner with auto tick loop (#8)

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	arbor "github.com/ToySin/go-arbor"
 )
@@ -110,4 +111,23 @@ func main() {
 	fmt.Println("\n[Tick 1]")
 	tree.Tick(context.Background())
 	arbor.PrintTree(os.Stdout, tree)
+
+	// --- Scenario 4: Auto tick with Run ---
+	fmt.Println("\n--- Scenario 4: Auto tick with Run (500ms interval) ---")
+	batteryLevel = 80
+	agentIdle = true
+	assignAttempts = 0
+	tree = buildTree()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tree.Run(ctx, 500*time.Millisecond,
+		arbor.WithTickCallback(func(e arbor.TickEvent) bool {
+			fmt.Printf("\n[Auto Tick %d] status=%s\n", e.Tick, e.Status)
+			arbor.PrintTree(os.Stdout, tree)
+			// Stop after tree completes (no more Running nodes).
+			return e.Status == arbor.Running
+		}),
+	)
 }

--- a/run_test.go
+++ b/run_test.go
@@ -1,0 +1,133 @@
+package arbor_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	arbor "github.com/ToySin/go-arbor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRun_RespectsContextCancellation(t *testing.T) {
+	var mu sync.Mutex
+	tickCount := 0
+
+	tree := arbor.NewTree(arbor.NewAction("inc", func(ctx context.Context) arbor.Status {
+		mu.Lock()
+		tickCount++
+		mu.Unlock()
+		return arbor.Success
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after enough time for at least one tick.
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	err := tree.Run(ctx, 1*time.Millisecond)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	mu.Lock()
+	assert.GreaterOrEqual(t, tickCount, 1)
+	mu.Unlock()
+}
+
+func TestRun_CallbackReceivesTickEvents(t *testing.T) {
+	var events []arbor.TickEvent
+
+	tree := arbor.NewTree(arbor.NewAction("ok", func(ctx context.Context) arbor.Status {
+		return arbor.Success
+	}))
+
+	err := tree.Run(context.Background(), 1*time.Millisecond,
+		arbor.WithTickCallback(func(e arbor.TickEvent) bool {
+			events = append(events, e)
+			return len(events) < 5
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, events, 5)
+	for i, e := range events {
+		assert.Equal(t, i+1, e.Tick)
+		assert.Equal(t, arbor.Success, e.Status)
+	}
+}
+
+func TestRun_CallbackStopsLoop(t *testing.T) {
+	tickCount := 0
+
+	tree := arbor.NewTree(arbor.NewAction("ok", func(ctx context.Context) arbor.Status {
+		tickCount++
+		return arbor.Success
+	}))
+
+	err := tree.Run(context.Background(), 1*time.Millisecond,
+		arbor.WithTickCallback(func(e arbor.TickEvent) bool {
+			return e.Tick < 3
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, tickCount)
+}
+
+func TestRun_NoCallback(t *testing.T) {
+	tree := arbor.NewTree(arbor.NewAction("ok", func(ctx context.Context) arbor.Status {
+		return arbor.Success
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	err := tree.Run(ctx, 1*time.Millisecond)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestRun_InvalidInterval(t *testing.T) {
+	tree := arbor.NewTree(arbor.NewAction("ok", func(ctx context.Context) arbor.Status {
+		return arbor.Success
+	}))
+
+	err := tree.Run(context.Background(), 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "interval must be positive")
+
+	err = tree.Run(context.Background(), -1*time.Second)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "interval must be positive")
+}
+
+func TestRun_RunningNodeResumesAcrossTicks(t *testing.T) {
+	tickCount := 0
+	seq := arbor.NewSequence("resume-seq",
+		arbor.NewAction("a1", func(ctx context.Context) arbor.Status {
+			return arbor.Success
+		}),
+		arbor.NewAction("a2", func(ctx context.Context) arbor.Status {
+			tickCount++
+			if tickCount < 3 {
+				return arbor.Running
+			}
+			return arbor.Success
+		}),
+	)
+
+	tree := arbor.NewTree(seq)
+	var events []arbor.TickEvent
+
+	err := tree.Run(context.Background(), 1*time.Millisecond,
+		arbor.WithTickCallback(func(e arbor.TickEvent) bool {
+			events = append(events, e)
+			// Stop after the sequence completes.
+			return e.Status != arbor.Success
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, events, 3)
+	assert.Equal(t, arbor.Running, events[0].Status)
+	assert.Equal(t, arbor.Running, events[1].Status)
+	assert.Equal(t, arbor.Success, events[2].Status)
+}

--- a/tree.go
+++ b/tree.go
@@ -1,6 +1,10 @@
 package arbor
 
-import "context"
+import (
+	"context"
+	"errors"
+	"time"
+)
 
 // Tree is the top-level container that drives tick execution from the root node.
 type Tree struct {
@@ -32,4 +36,56 @@ func (t *Tree) Blackboard() *Blackboard {
 // Root returns the root node of the tree.
 func (t *Tree) Root() Node {
 	return t.root
+}
+
+// TickEvent contains information about a completed tick.
+type TickEvent struct {
+	Tick   int
+	Status Status
+}
+
+// RunOption configures the behavior of Tree.Run.
+type RunOption func(*runConfig)
+
+type runConfig struct {
+	callback func(TickEvent) bool
+}
+
+// WithTickCallback registers a function called after each tick.
+// Return true to continue, false to stop the run loop early.
+func WithTickCallback(fn func(TickEvent) bool) RunOption {
+	return func(cfg *runConfig) {
+		cfg.callback = fn
+	}
+}
+
+// Run executes the tree's tick loop at the given interval until the context
+// is cancelled or a callback returns false.
+// Returns the context's error when the loop exits due to cancellation,
+// or nil when a callback stops the loop.
+func (t *Tree) Run(ctx context.Context, interval time.Duration, opts ...RunOption) error {
+	if interval <= 0 {
+		return errors.New("arbor: interval must be positive")
+	}
+	cfg := &runConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	tick := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			tick++
+			status := t.Tick(ctx)
+			if cfg.callback != nil {
+				if !cfg.callback(TickEvent{Tick: tick, Status: status}) {
+					return nil
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Add `Tree.Run(ctx, interval, ...RunOption)` — blocking tick loop using `time.NewTicker` for fixed-period scheduling
- Add `WithTickCallback(fn)` functional option for per-tick event handling (callback returns `false` to stop early)
- Guard against non-positive interval with clear error message
- Closes #8

## Test plan
- [x] `TestRun_RespectsContextCancellation` — cancel ctx → returns `context.Canceled`
- [x] `TestRun_CallbackReceivesTickEvents` — sequential tick numbers + correct status
- [x] `TestRun_CallbackStopsLoop` — callback returns false → Run returns nil, exact tick count
- [x] `TestRun_NoCallback` — works without options
- [x] `TestRun_InvalidInterval` — zero/negative interval → error
- [x] `TestRun_RunningNodeResumesAcrossTicks` — Sequence with Running child progresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)