### PR TITLE
feat: implement fluent tree builder API (#10)

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -1,0 +1,189 @@
+package arbor
+
+import (
+	"fmt"
+	"time"
+)
+
+// Builder provides a fluent API for constructing behavior trees.
+//
+// Composite and decorator methods open a new scope that collects children
+// until End() is called. Leaf methods add nodes directly to the current scope.
+//
+// Example:
+//
+//	tree, err := arbor.NewBuilder().
+//	    Sequence("dispatch").
+//	        Condition("agent-idle", isIdle).
+//	        Action("assign-job", assignJob).
+//	        Action("notify", notify).
+//	    End().
+//	    Build()
+type Builder struct {
+	stack []*builderScope
+	err   error
+}
+
+type builderScope struct {
+	name           string
+	children       []Node
+	buildComposite func(children []Node) Node
+	buildDecorator func(child Node) Node
+}
+
+func (s *builderScope) isDecorator() bool {
+	return s.buildDecorator != nil
+}
+
+// NewBuilder creates a new Builder with an empty root scope.
+func NewBuilder() *Builder {
+	return &Builder{
+		stack: []*builderScope{{}},
+	}
+}
+
+func (b *Builder) current() *builderScope {
+	return b.stack[len(b.stack)-1]
+}
+
+func (b *Builder) pushComposite(name string, build func(children []Node) Node) *Builder {
+	if b.err != nil {
+		return b
+	}
+	b.stack = append(b.stack, &builderScope{
+		name:           name,
+		buildComposite: build,
+	})
+	return b
+}
+
+func (b *Builder) pushDecorator(name string, build func(child Node) Node) *Builder {
+	if b.err != nil {
+		return b
+	}
+	b.stack = append(b.stack, &builderScope{
+		name:           name,
+		buildDecorator: build,
+	})
+	return b
+}
+
+func (b *Builder) addLeaf(node Node) *Builder {
+	if b.err != nil {
+		return b
+	}
+	b.current().children = append(b.current().children, node)
+	return b
+}
+
+// Sequence opens a Sequence scope.
+func (b *Builder) Sequence(name string) *Builder {
+	return b.pushComposite(name, func(children []Node) Node {
+		return NewSequence(name, children...)
+	})
+}
+
+// Fallback opens a Fallback scope.
+func (b *Builder) Fallback(name string) *Builder {
+	return b.pushComposite(name, func(children []Node) Node {
+		return NewFallback(name, children...)
+	})
+}
+
+// Parallel opens a Parallel scope.
+func (b *Builder) Parallel(name string, opts ...ParallelOption) *Builder {
+	return b.pushComposite(name, func(children []Node) Node {
+		return NewParallel(name, children, opts...)
+	})
+}
+
+// Inverter opens an Inverter scope (expects exactly one child before End).
+func (b *Builder) Inverter(name string) *Builder {
+	return b.pushDecorator(name, func(child Node) Node {
+		return NewInverter(name, child)
+	})
+}
+
+// Repeater opens a Repeater scope (expects exactly one child before End).
+func (b *Builder) Repeater(name string, n int) *Builder {
+	return b.pushDecorator(name, func(child Node) Node {
+		return NewRepeater(name, n, child)
+	})
+}
+
+// Retry opens a Retry scope (expects exactly one child before End).
+func (b *Builder) Retry(name string, maxRetries int) *Builder {
+	return b.pushDecorator(name, func(child Node) Node {
+		return NewRetry(name, maxRetries, child)
+	})
+}
+
+// Timeout opens a Timeout scope (expects exactly one child before End).
+func (b *Builder) Timeout(name string, d time.Duration) *Builder {
+	return b.pushDecorator(name, func(child Node) Node {
+		return NewTimeout(name, d, child)
+	})
+}
+
+// Action adds an Action leaf to the current scope.
+func (b *Builder) Action(name string, fn ActionFunc) *Builder {
+	return b.addLeaf(NewAction(name, fn))
+}
+
+// Condition adds a Condition leaf to the current scope.
+func (b *Builder) Condition(name string, fn ConditionFunc) *Builder {
+	return b.addLeaf(NewCondition(name, fn))
+}
+
+// End closes the current scope and adds the resulting node to the parent scope.
+func (b *Builder) End() *Builder {
+	if b.err != nil {
+		return b
+	}
+	if len(b.stack) <= 1 {
+		b.err = fmt.Errorf("arbor: End() called without matching open scope")
+		return b
+	}
+
+	current := b.current()
+	b.stack = b.stack[:len(b.stack)-1]
+
+	if current.isDecorator() {
+		if len(current.children) != 1 {
+			b.err = fmt.Errorf("arbor: decorator %q expects exactly 1 child, got %d", current.name, len(current.children))
+			return b
+		}
+		b.current().children = append(b.current().children, current.buildDecorator(current.children[0]))
+	} else {
+		if len(current.children) == 0 {
+			b.err = fmt.Errorf("arbor: composite %q has no children", current.name)
+			return b
+		}
+		b.current().children = append(b.current().children, current.buildComposite(current.children))
+	}
+	return b
+}
+
+// Build validates the tree structure and returns the constructed Tree.
+func (b *Builder) Build() (*Tree, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+	if len(b.stack) != 1 {
+		return nil, fmt.Errorf("arbor: %d unclosed scope(s), missing End() call(s)", len(b.stack)-1)
+	}
+	root := b.stack[0]
+	if len(root.children) != 1 {
+		return nil, fmt.Errorf("arbor: tree must have exactly 1 root node, got %d", len(root.children))
+	}
+	return NewTree(root.children[0]), nil
+}
+
+// MustBuild calls Build and panics if the tree is invalid.
+func (b *Builder) MustBuild() *Tree {
+	tree, err := b.Build()
+	if err != nil {
+		panic(err)
+	}
+	return tree
+}

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,0 +1,256 @@
+package arbor_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	arbor "github.com/ToySin/go-arbor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilder_IssueExample(t *testing.T) {
+	isIdle := func(ctx context.Context) bool { return true }
+	assignJob := func(ctx context.Context) arbor.Status { return arbor.Success }
+	notify := func(ctx context.Context) arbor.Status { return arbor.Success }
+
+	tree, err := arbor.NewBuilder().
+		Sequence("dispatch").
+		Condition("agent-idle", isIdle).
+		Action("assign-job", assignJob).
+		Action("notify", notify).
+		End().
+		Build()
+
+	require.NoError(t, err)
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()))
+}
+
+func TestBuilder_NestedComposites(t *testing.T) {
+	tree, err := arbor.NewBuilder().
+		Fallback("root").
+		Sequence("try-first").
+		Action("fail", func(ctx context.Context) arbor.Status {
+				return arbor.Failure
+			}).
+		End().
+		Action("fallback-action", func(ctx context.Context) arbor.Status {
+				return arbor.Success
+			}).
+		End().
+		Build()
+
+	require.NoError(t, err)
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()))
+}
+
+func TestBuilder_DecoratorWrapsLeaf(t *testing.T) {
+	tree, err := arbor.NewBuilder().
+		Inverter("flip").
+		Action("fail", func(ctx context.Context) arbor.Status {
+				return arbor.Failure
+			}).
+		End().
+		Build()
+
+	require.NoError(t, err)
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()))
+}
+
+func TestBuilder_DecoratorWrapsComposite(t *testing.T) {
+	tree, err := arbor.NewBuilder().
+		Inverter("flip").
+		Sequence("seq").
+		Action("fail", func(ctx context.Context) arbor.Status {
+					return arbor.Failure
+				}).
+		End().
+		End().
+		Build()
+
+	require.NoError(t, err)
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()))
+}
+
+func TestBuilder_Retry(t *testing.T) {
+	attempts := 0
+	tree, err := arbor.NewBuilder().
+		Retry("retry", 3).
+		Action("flaky", func(ctx context.Context) arbor.Status {
+				attempts++
+				if attempts < 3 {
+					return arbor.Failure
+				}
+				return arbor.Success
+			}).
+		End().
+		Build()
+
+	require.NoError(t, err)
+	// Retry ticks the child once per tree tick, retrying on failure.
+	for tree.Tick(context.Background()) == arbor.Running {
+	}
+	assert.Equal(t, 3, attempts)
+}
+
+func TestBuilder_Repeater(t *testing.T) {
+	count := 0
+	tree, err := arbor.NewBuilder().
+		Repeater("repeat", 3).
+		Action("inc", func(ctx context.Context) arbor.Status {
+				count++
+				return arbor.Success
+			}).
+		End().
+		Build()
+
+	require.NoError(t, err)
+	for tree.Tick(context.Background()) == arbor.Running {
+	}
+	assert.Equal(t, 3, count)
+}
+
+func TestBuilder_Timeout(t *testing.T) {
+	tree, err := arbor.NewBuilder().
+		Timeout("quick", 10*time.Millisecond).
+		Action("slow", func(ctx context.Context) arbor.Status {
+				return arbor.Running
+			}).
+		End().
+		Build()
+
+	require.NoError(t, err)
+	// First tick starts the timer.
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()))
+	// After timeout expires, should fail.
+	time.Sleep(15 * time.Millisecond)
+	assert.Equal(t, arbor.Failure, tree.Tick(context.Background()))
+}
+
+func TestBuilder_Parallel(t *testing.T) {
+	tree, err := arbor.NewBuilder().
+		Parallel("all", arbor.WithSuccessThreshold(2)).
+		Action("a1", func(ctx context.Context) arbor.Status { return arbor.Success }).
+		Action("a2", func(ctx context.Context) arbor.Status { return arbor.Success }).
+		Action("a3", func(ctx context.Context) arbor.Status { return arbor.Running }).
+		End().
+		Build()
+
+	require.NoError(t, err)
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()))
+}
+
+func TestBuilder_Error_UnclosedScope(t *testing.T) {
+	_, err := arbor.NewBuilder().
+		Sequence("open").
+		Action("a", func(ctx context.Context) arbor.Status { return arbor.Success }).
+		Build()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unclosed scope")
+}
+
+func TestBuilder_Error_ExtraEnd(t *testing.T) {
+	_, err := arbor.NewBuilder().
+		Sequence("s").
+		Action("a", func(ctx context.Context) arbor.Status { return arbor.Success }).
+		End().
+		End().
+		Build()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "without matching open scope")
+}
+
+func TestBuilder_Error_EmptyComposite(t *testing.T) {
+	_, err := arbor.NewBuilder().
+		Sequence("empty").
+		End().
+		Build()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no children")
+}
+
+func TestBuilder_Error_DecoratorTooManyChildren(t *testing.T) {
+	_, err := arbor.NewBuilder().
+		Inverter("flip").
+		Action("a1", func(ctx context.Context) arbor.Status { return arbor.Success }).
+		Action("a2", func(ctx context.Context) arbor.Status { return arbor.Success }).
+		End().
+		Build()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly 1 child")
+}
+
+func TestBuilder_Error_DecoratorNoChild(t *testing.T) {
+	_, err := arbor.NewBuilder().
+		Inverter("flip").
+		End().
+		Build()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly 1 child")
+}
+
+func TestBuilder_Error_EmptyTree(t *testing.T) {
+	_, err := arbor.NewBuilder().Build()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly 1 root node, got 0")
+}
+
+func TestBuilder_MustBuild_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		arbor.NewBuilder().MustBuild()
+	})
+}
+
+func TestBuilder_MustBuild_Success(t *testing.T) {
+	assert.NotPanics(t, func() {
+		tree := arbor.NewBuilder().
+			Action("ok", func(ctx context.Context) arbor.Status { return arbor.Success }).
+			MustBuild()
+		assert.Equal(t, arbor.Success, tree.Tick(context.Background()))
+	})
+}
+
+func TestBuilder_EquivalentToManual(t *testing.T) {
+	fn := func(ctx context.Context) arbor.Status { return arbor.Success }
+	cond := func(ctx context.Context) bool { return true }
+
+	// Build with builder.
+	builderTree, err := arbor.NewBuilder().
+		Fallback("root").
+		Sequence("path-a").
+		Condition("check", cond).
+		Inverter("flip").
+		Condition("neg-check", cond).
+		End().
+		Action("do", fn).
+		End().
+		Action("path-b", fn).
+		End().
+		Build()
+	require.NoError(t, err)
+
+	// Build manually.
+	manualTree := arbor.NewTree(
+		arbor.NewFallback("root",
+			arbor.NewSequence("path-a",
+				arbor.NewCondition("check", cond),
+				arbor.NewInverter("flip",
+					arbor.NewCondition("neg-check", cond),
+				),
+				arbor.NewAction("do", fn),
+			),
+			arbor.NewAction("path-b", fn),
+		),
+	)
+
+	// Both should produce same tick result.
+	ctx := context.Background()
+	assert.Equal(t, manualTree.Tick(ctx), builderTree.Tick(ctx))
+}

--- a/example/main.go
+++ b/example/main.go
@@ -112,8 +112,68 @@ func main() {
 	tree.Tick(context.Background())
 	arbor.PrintTree(os.Stdout, tree)
 
-	// --- Scenario 4: Auto tick with Run ---
-	fmt.Println("\n--- Scenario 4: Auto tick with Run (500ms interval) ---")
+	// --- Scenario 4: Build tree with fluent builder ---
+	fmt.Println("\n--- Scenario 4: Fluent Builder API ---")
+	assignAttempts = 0
+	agentIdle = true
+	batteryLevel = 80
+
+	builderTree := arbor.NewBuilder().
+		Fallback("dispatch").
+		Sequence("try-assign").
+		Condition("agent-idle", func(ctx context.Context) bool {
+					return agentIdle
+				}).
+		Inverter("not-low-battery").
+		Condition("battery-low", func(ctx context.Context) bool {
+							return batteryLevel < 20
+						}).
+		End().
+		Action("find-agent", func(ctx context.Context) arbor.Status {
+					bb := arbor.BlackboardFrom(ctx)
+					bb.Set("target_agent", "agent-7")
+					bb.Set("job_id", "job-42")
+					fmt.Println("  >> Found best agent: agent-7")
+					return arbor.Success
+				}).
+		Retry("retry-assign", 3).
+		Action("assign-job", func(ctx context.Context) arbor.Status {
+						bb := arbor.BlackboardFrom(ctx)
+						agent, _ := arbor.GetTyped[string](bb, "target_agent")
+						jobID, _ := arbor.GetTyped[string](bb, "job_id")
+						assignAttempts++
+						if assignAttempts < 2 {
+							fmt.Printf("  >> Assign %s to %s failed (attempt %d)\n", jobID, agent, assignAttempts)
+							return arbor.Failure
+						}
+						fmt.Printf("  >> Assigned %s to %s\n", jobID, agent)
+						return arbor.Success
+					}).
+		End().
+		Action("notify", func(ctx context.Context) arbor.Status {
+					bb := arbor.BlackboardFrom(ctx)
+					agent, _ := arbor.GetTyped[string](bb, "target_agent")
+					fmt.Printf("  >> Notified %s\n", agent)
+					return arbor.Success
+				}).
+		End().
+		Action("queue-job", func(ctx context.Context) arbor.Status {
+				fmt.Println("  >> No suitable agent, job queued")
+				return arbor.Success
+			}).
+		End().
+		MustBuild()
+
+	fmt.Println("\n[Tick 1]")
+	builderTree.Tick(context.Background())
+	arbor.PrintTree(os.Stdout, builderTree)
+
+	fmt.Println("\n[Tick 2]")
+	builderTree.Tick(context.Background())
+	arbor.PrintTree(os.Stdout, builderTree)
+
+	// --- Scenario 5: Auto tick with Run ---
+	fmt.Println("\n--- Scenario 5: Auto tick with Run (500ms interval) ---")
 	batteryLevel = 80
 	agentIdle = true
 	assignAttempts = 0


### PR DESCRIPTION
## Summary
- Add `Builder` with fluent/chainable API for tree construction
- Stack-based scope management: composite/decorator methods push scopes, `End()` pops and builds
- All node types supported: Sequence, Fallback, Parallel, Inverter, Repeater, Retry, Timeout, Action, Condition
- `Build()` validates structure (empty composites, decorator child count, unclosed scopes)
- `MustBuild()` convenience wrapper that panics on error
- Closes #10

## Example
```go
tree, err := arbor.NewBuilder().
    Sequence("dispatch").
        Condition("agent-idle", isIdle).
        Action("assign-job", assignJob).
        Action("notify", notify).
    End().
    Build()
```

## Test plan
- [x] Issue example (happy path)
- [x] Nested composites (Fallback > Sequence)
- [x] Decorator wrapping leaf / composite
- [x] Retry, Repeater, Timeout, Parallel with options
- [x] Error: unclosed scope, extra End(), empty composite, decorator child count, empty tree
- [x] MustBuild panics / succeeds
- [x] Equivalence with manually constructed tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)