### PR TITLE
feat: implement Halt mechanism for node interruption

### DIFF
--- a/composite.go
+++ b/composite.go
@@ -42,6 +42,15 @@ func (s *Sequence) Tick(ctx context.Context) Status {
 	return Success
 }
 
+// Halt interrupts the Sequence and halts the currently Running child.
+func (s *Sequence) Halt() {
+	if s.current < len(s.children) {
+		haltNode(s.children[s.current])
+	}
+	s.current = 0
+	s.lastStatus = nil
+}
+
 // LastStatus returns the result of the most recent tick (implements Stateful).
 func (s *Sequence) LastStatus() *Status {
 	return s.lastStatus
@@ -95,6 +104,15 @@ func (f *Fallback) Tick(ctx context.Context) Status {
 	f.current = 0
 	f.lastStatus = statusPtr(Failure)
 	return Failure
+}
+
+// Halt interrupts the Fallback and halts the currently Running child.
+func (f *Fallback) Halt() {
+	if f.current < len(f.children) {
+		haltNode(f.children[f.current])
+	}
+	f.current = 0
+	f.lastStatus = nil
 }
 
 // LastStatus returns the result of the most recent tick (implements Stateful).
@@ -209,6 +227,17 @@ func (p *Parallel) reset() {
 	for i := range p.done {
 		p.done[i] = false
 	}
+}
+
+// Halt interrupts the Parallel and halts all Running children.
+func (p *Parallel) Halt() {
+	for i, child := range p.children {
+		if !p.done[i] {
+			haltNode(child)
+		}
+	}
+	p.reset()
+	p.lastStatus = nil
 }
 
 // LastStatus returns the result of the most recent tick (implements Stateful).

--- a/decorator.go
+++ b/decorator.go
@@ -33,6 +33,12 @@ func (inv *Inverter) Tick(ctx context.Context) Status {
 	}
 }
 
+// Halt propagates halt to the child and resets state.
+func (inv *Inverter) Halt() {
+	haltNode(inv.child)
+	inv.lastStatus = nil
+}
+
 // Children returns the child node of the Inverter.
 func (inv *Inverter) Children() []Node { return []Node{inv.child} }
 
@@ -81,6 +87,13 @@ func (r *Repeater) Tick(ctx context.Context) Status {
 		return Running
 	}
 	return Failure
+}
+
+// Halt propagates halt to the child and resets the repeat counter.
+func (r *Repeater) Halt() {
+	haltNode(r.child)
+	r.current = 0
+	r.lastStatus = nil
 }
 
 // Children returns the child node of the Repeater.
@@ -132,6 +145,13 @@ func (r *Retry) Tick(ctx context.Context) Status {
 	return Failure
 }
 
+// Halt propagates halt to the child and resets the attempt counter.
+func (r *Retry) Halt() {
+	haltNode(r.child)
+	r.attempts = 0
+	r.lastStatus = nil
+}
+
 // Children returns the child node of the Retry.
 func (r *Retry) Children() []Node { return []Node{r.child} }
 
@@ -179,6 +199,13 @@ func (t *Timeout) Tick(ctx context.Context) Status {
 		t.lastStatus = statusPtr(status)
 		return status
 	}
+}
+
+// Halt propagates halt to the child and resets the timer.
+func (t *Timeout) Halt() {
+	haltNode(t.child)
+	t.running = false
+	t.lastStatus = nil
 }
 
 // Children returns the child node of the Timeout.

--- a/halt_test.go
+++ b/halt_test.go
@@ -1,0 +1,203 @@
+package arbor_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	arbor "github.com/ToySin/go-arbor"
+)
+
+func TestSequence_Halt_ResetsCurrentChild(t *testing.T) {
+	tickCount := 0
+	seq := arbor.NewSequence("seq",
+		arbor.NewAction("a1", func(ctx context.Context) arbor.Status {
+			tickCount++
+			return arbor.Success
+		}),
+		arbor.NewAction("a2", func(ctx context.Context) arbor.Status {
+			return arbor.Running
+		}),
+	)
+
+	tree := arbor.NewTree(seq)
+
+	// Tick 1: a1 Success, a2 Running → Sequence Running at child 1
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()))
+	assert.Equal(t, 1, tickCount)
+
+	// Halt → should reset to child 0
+	seq.Halt()
+
+	// Tick 2: should start from a1 again
+	tree.Tick(context.Background())
+	assert.Equal(t, 2, tickCount, "a1 should be ticked again after halt")
+}
+
+func TestFallback_Halt_ResetsCurrentChild(t *testing.T) {
+	tickCount := 0
+	fb := arbor.NewFallback("fb",
+		arbor.NewAction("a1", func(ctx context.Context) arbor.Status {
+			tickCount++
+			return arbor.Running
+		}),
+		arbor.NewAction("a2", func(ctx context.Context) arbor.Status {
+			return arbor.Success
+		}),
+	)
+
+	tree := arbor.NewTree(fb)
+
+	// Tick 1: a1 Running → Fallback Running at child 0
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()))
+	assert.Equal(t, 1, tickCount)
+
+	// Halt → should reset
+	fb.Halt()
+
+	// Tick 2: should start from a1 again
+	tree.Tick(context.Background())
+	assert.Equal(t, 2, tickCount, "a1 should be ticked again after halt")
+}
+
+func TestHalt_PropagatesDownTree(t *testing.T) {
+	innerHalted := false
+	seq := arbor.NewSequence("outer",
+		arbor.NewSequence("inner",
+			arbor.NewAction("work", func(ctx context.Context) arbor.Status {
+				return arbor.Running
+			}, arbor.WithHaltFunc(func() {
+				innerHalted = true
+			})),
+		),
+	)
+
+	tree := arbor.NewTree(seq)
+	tree.Tick(context.Background())
+
+	seq.Halt()
+
+	assert.True(t, innerHalted, "halt should propagate to inner action")
+}
+
+func TestAction_HaltFunc_Called(t *testing.T) {
+	halted := false
+	action := arbor.NewAction("work",
+		func(ctx context.Context) arbor.Status { return arbor.Running },
+		arbor.WithHaltFunc(func() {
+			halted = true
+		}),
+	)
+
+	action.Tick(context.Background())
+	action.Halt()
+
+	assert.True(t, halted)
+}
+
+func TestAction_HaltFunc_NotSet(t *testing.T) {
+	action := arbor.NewAction("work",
+		func(ctx context.Context) arbor.Status { return arbor.Running },
+	)
+
+	action.Tick(context.Background())
+	action.Halt() // should not panic
+
+	assert.Nil(t, action.LastStatus())
+}
+
+func TestCondition_Halt_ResetsStatus(t *testing.T) {
+	cond := arbor.NewCondition("check", func(ctx context.Context) bool {
+		return true
+	})
+
+	cond.Tick(context.Background())
+	assert.NotNil(t, cond.LastStatus())
+
+	cond.Halt()
+	assert.Nil(t, cond.LastStatus())
+}
+
+func TestParallel_Halt_HaltsAllRunningChildren(t *testing.T) {
+	halt1 := false
+	halt2 := false
+	p := arbor.NewParallel("par", []arbor.Node{
+		arbor.NewAction("a1",
+			func(ctx context.Context) arbor.Status { return arbor.Running },
+			arbor.WithHaltFunc(func() { halt1 = true }),
+		),
+		arbor.NewAction("a2",
+			func(ctx context.Context) arbor.Status { return arbor.Running },
+			arbor.WithHaltFunc(func() { halt2 = true }),
+		),
+	})
+
+	tree := arbor.NewTree(p)
+	tree.Tick(context.Background())
+
+	p.Halt()
+
+	assert.True(t, halt1, "a1 should be halted")
+	assert.True(t, halt2, "a2 should be halted")
+}
+
+func TestDecorator_Halt_Propagates(t *testing.T) {
+	halted := false
+
+	inv := arbor.NewInverter("inv",
+		arbor.NewAction("work",
+			func(ctx context.Context) arbor.Status { return arbor.Running },
+			arbor.WithHaltFunc(func() { halted = true }),
+		),
+	)
+	inv.Tick(context.Background())
+	inv.Halt()
+	assert.True(t, halted, "inverter should propagate halt")
+}
+
+func TestRepeater_Halt_ResetsCounter(t *testing.T) {
+	count := 0
+	rep := arbor.NewRepeater("rep", 3,
+		arbor.NewAction("work", func(ctx context.Context) arbor.Status {
+			count++
+			return arbor.Success
+		}),
+	)
+
+	tree := arbor.NewTree(rep)
+	tree.Tick(context.Background()) // count=1, internal=1/3 → Running
+	tree.Tick(context.Background()) // count=2, internal=2/3 → Running
+
+	rep.Halt() // reset internal counter to 0
+
+	// After halt, needs 3 more successes (not 1)
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()), "tick after halt: 1/3")
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()), "tick after halt: 2/3")
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()), "tick after halt: 3/3")
+	assert.Equal(t, 5, count)
+}
+
+func TestRetry_Halt_ResetsAttempts(t *testing.T) {
+	attempts := 0
+	r := arbor.NewRetry("retry", 3,
+		arbor.NewAction("flaky", func(ctx context.Context) arbor.Status {
+			attempts++
+			return arbor.Failure
+		}),
+	)
+
+	tree := arbor.NewTree(r)
+	tree.Tick(context.Background()) // attempt 1
+	tree.Tick(context.Background()) // attempt 2
+
+	r.Halt() // reset attempts
+
+	// Should start fresh — 3 more failures needed to exhaust
+	tree.Tick(context.Background()) // attempt 1 (reset)
+	tree.Tick(context.Background()) // attempt 2
+	status := tree.Tick(context.Background()) // attempt 3 → exhausted
+
+	assert.Equal(t, arbor.Failure, status)
+	assert.Equal(t, 5, attempts) // 2 before halt + 3 after
+}

--- a/leaf.go
+++ b/leaf.go
@@ -11,19 +11,34 @@ import "context"
 // it should return Failure.
 type ActionFunc func(ctx context.Context) Status
 
+// ActionOption configures an Action node.
+type ActionOption func(*Action)
+
+// WithHaltFunc sets a function to be called when the Action is halted.
+func WithHaltFunc(fn func()) ActionOption {
+	return func(a *Action) {
+		a.haltFn = fn
+	}
+}
+
 // Action is a leaf node that executes a user-provided function.
 type Action struct {
 	name       string
 	fn         ActionFunc
+	haltFn     func()
 	lastStatus *Status
 }
 
 // NewAction creates a new Action node with the given name and function.
-func NewAction(name string, fn ActionFunc) *Action {
-	return &Action{
+func NewAction(name string, fn ActionFunc, opts ...ActionOption) *Action {
+	a := &Action{
 		name: name,
 		fn:   fn,
 	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
 }
 
 // Tick executes the action's function and returns its status.
@@ -36,6 +51,14 @@ func (a *Action) Tick(ctx context.Context) Status {
 // String returns the name of the action (implements fmt.Stringer).
 func (a *Action) String() string {
 	return a.name
+}
+
+// Halt calls the optional halt function if set, and resets lastStatus.
+func (a *Action) Halt() {
+	if a.haltFn != nil {
+		a.haltFn()
+	}
+	a.lastStatus = nil
 }
 
 // LastStatus returns the result of the most recent tick (implements Stateful).
@@ -72,6 +95,11 @@ func (c *Condition) Tick(ctx context.Context) Status {
 	}
 	c.lastStatus = statusPtr(status)
 	return status
+}
+
+// Halt resets the condition's lastStatus.
+func (c *Condition) Halt() {
+	c.lastStatus = nil
 }
 
 // String returns the name of the condition (implements fmt.Stringer).

--- a/node.go
+++ b/node.go
@@ -54,6 +54,20 @@ type Stateful interface {
 	LastStatus() *Status
 }
 
+// Haltable is implemented by nodes that can be interrupted while Running.
+// When a composite switches branches, it calls Halt() on the previously Running child.
+// Halt should reset internal state and propagate to Running children.
+type Haltable interface {
+	Halt()
+}
+
+// haltNode calls Halt() on the node if it implements Haltable.
+func haltNode(n Node) {
+	if h, ok := n.(Haltable); ok {
+		h.Halt()
+	}
+}
+
 func statusPtr(s Status) *Status {
 	return &s
 }


### PR DESCRIPTION
Changelog
======
- Add `Haltable` interface with `Halt()` method
- Implement Halt on all composite nodes (Sequence, Fallback, Parallel)
- Implement Halt on all decorator nodes (Inverter, Repeater, Retry, Timeout)
- Add `WithHaltFunc` option for Action nodes with custom cleanup
- Condition and Action reset `lastStatus` on Halt
- `haltNode()` helper for safe halt propagation
- Halt propagates down the tree — halting a composite halts its Running children

Closes #23

Testing
======
- `go test ./...` — all PASS
- 11 halt-specific tests: composite reset, propagation, Action haltFunc, Parallel halts all Running, decorator propagation, Repeater/Retry counter reset