### PR TITLE
feat: implement ReactiveSequence and ReactiveFallback

### DIFF
--- a/reactive.go
+++ b/reactive.go
@@ -1,0 +1,138 @@
+package arbor
+
+import "context"
+
+// ReactiveSequence ticks children from the first child on every tick.
+// Unlike Sequence, it does NOT resume from the previously Running child.
+// If a child that was previously Success now fails, Running children are halted.
+// This enables "guard condition" patterns where conditions are re-checked every tick.
+type ReactiveSequence struct {
+	name       string
+	children   []Node
+	running    int // index of the currently Running child, -1 if none
+	lastStatus *Status
+}
+
+// NewReactiveSequence creates a new ReactiveSequence node.
+func NewReactiveSequence(name string, children ...Node) *ReactiveSequence {
+	return &ReactiveSequence{
+		name:     name,
+		children: children,
+		running:  -1,
+	}
+}
+
+// Tick always starts from child 0. If a previously Running child is no longer
+// the active Running node, it is halted.
+func (rs *ReactiveSequence) Tick(ctx context.Context) Status {
+	for i, child := range rs.children {
+		status := child.Tick(ctx)
+		switch status {
+		case Running:
+			// If a different child was Running before, halt it
+			if rs.running != -1 && rs.running != i {
+				haltNode(rs.children[rs.running])
+			}
+			rs.running = i
+			rs.lastStatus = statusPtr(Running)
+			return Running
+		case Failure:
+			// Halt the previously Running child if any
+			if rs.running != -1 {
+				haltNode(rs.children[rs.running])
+				rs.running = -1
+			}
+			rs.lastStatus = statusPtr(Failure)
+			return Failure
+		}
+	}
+	// All succeeded
+	rs.running = -1
+	rs.lastStatus = statusPtr(Success)
+	return Success
+}
+
+// Halt interrupts the ReactiveSequence and halts the Running child.
+func (rs *ReactiveSequence) Halt() {
+	if rs.running != -1 {
+		haltNode(rs.children[rs.running])
+		rs.running = -1
+	}
+	rs.lastStatus = nil
+}
+
+// Children returns the child nodes (implements Parent).
+func (rs *ReactiveSequence) Children() []Node { return rs.children }
+
+// String returns the name (implements fmt.Stringer).
+func (rs *ReactiveSequence) String() string { return rs.name }
+
+// LastStatus returns the last tick result (implements Stateful).
+func (rs *ReactiveSequence) LastStatus() *Status { return rs.lastStatus }
+
+// ReactiveFallback ticks children from the first child on every tick.
+// Unlike Fallback, it does NOT resume from the previously Running child.
+// If a higher-priority child now succeeds, the previously Running child is halted.
+type ReactiveFallback struct {
+	name       string
+	children   []Node
+	running    int // index of the currently Running child, -1 if none
+	lastStatus *Status
+}
+
+// NewReactiveFallback creates a new ReactiveFallback node.
+func NewReactiveFallback(name string, children ...Node) *ReactiveFallback {
+	return &ReactiveFallback{
+		name:     name,
+		children: children,
+		running:  -1,
+	}
+}
+
+// Tick always starts from child 0. If a higher-priority child succeeds,
+// the previously Running lower-priority child is halted.
+func (rf *ReactiveFallback) Tick(ctx context.Context) Status {
+	for i, child := range rf.children {
+		status := child.Tick(ctx)
+		switch status {
+		case Running:
+			// If a different child was Running before, halt it
+			if rf.running != -1 && rf.running != i {
+				haltNode(rf.children[rf.running])
+			}
+			rf.running = i
+			rf.lastStatus = statusPtr(Running)
+			return Running
+		case Success:
+			// Halt the previously Running child if any
+			if rf.running != -1 {
+				haltNode(rf.children[rf.running])
+				rf.running = -1
+			}
+			rf.lastStatus = statusPtr(Success)
+			return Success
+		}
+	}
+	// All failed
+	rf.running = -1
+	rf.lastStatus = statusPtr(Failure)
+	return Failure
+}
+
+// Halt interrupts the ReactiveFallback and halts the Running child.
+func (rf *ReactiveFallback) Halt() {
+	if rf.running != -1 {
+		haltNode(rf.children[rf.running])
+		rf.running = -1
+	}
+	rf.lastStatus = nil
+}
+
+// Children returns the child nodes (implements Parent).
+func (rf *ReactiveFallback) Children() []Node { return rf.children }
+
+// String returns the name (implements fmt.Stringer).
+func (rf *ReactiveFallback) String() string { return rf.name }
+
+// LastStatus returns the last tick result (implements Stateful).
+func (rf *ReactiveFallback) LastStatus() *Status { return rf.lastStatus }

--- a/reactive_test.go
+++ b/reactive_test.go
@@ -1,0 +1,200 @@
+package arbor_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	arbor "github.com/ToySin/go-arbor"
+)
+
+// --- ReactiveSequence ---
+
+func TestReactiveSequence_ReEvaluatesFromStart(t *testing.T) {
+	condResult := true
+	condTickCount := 0
+
+	tree := arbor.NewTree(
+		arbor.NewReactiveSequence("reactive",
+			arbor.NewCondition("guard", func(ctx context.Context) bool {
+				condTickCount++
+				return condResult
+			}),
+			arbor.NewAction("work", func(ctx context.Context) arbor.Status {
+				return arbor.Running
+			}),
+		),
+	)
+
+	// Tick 1: guard=Success, work=Running → Running
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()))
+	assert.Equal(t, 1, condTickCount)
+
+	// Tick 2: guard re-evaluated (still true), work=Running
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()))
+	assert.Equal(t, 2, condTickCount, "guard should be re-evaluated every tick")
+}
+
+func TestReactiveSequence_HaltsOnConditionChange(t *testing.T) {
+	condResult := true
+	workHalted := false
+
+	tree := arbor.NewTree(
+		arbor.NewReactiveSequence("reactive",
+			arbor.NewCondition("battery-ok", func(ctx context.Context) bool {
+				return condResult
+			}),
+			arbor.NewAction("work",
+				func(ctx context.Context) arbor.Status { return arbor.Running },
+				arbor.WithHaltFunc(func() { workHalted = true }),
+			),
+		),
+	)
+
+	// Tick 1: condition true, work Running
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()))
+	assert.False(t, workHalted)
+
+	// Condition changes
+	condResult = false
+
+	// Tick 2: condition fails → work should be halted → Failure
+	assert.Equal(t, arbor.Failure, tree.Tick(context.Background()))
+	assert.True(t, workHalted, "work should be halted when guard fails")
+}
+
+func TestReactiveSequence_AllSuccess(t *testing.T) {
+	tree := arbor.NewTree(
+		arbor.NewReactiveSequence("all-ok",
+			arbor.NewCondition("check", func(ctx context.Context) bool { return true }),
+			arbor.NewAction("work", func(ctx context.Context) arbor.Status { return arbor.Success }),
+		),
+	)
+
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()))
+}
+
+func TestReactiveSequence_HaltsWhenDifferentChildRunning(t *testing.T) {
+	tick := 0
+	child1Halted := false
+
+	tree := arbor.NewTree(
+		arbor.NewReactiveSequence("reactive",
+			arbor.NewAction("a1",
+				func(ctx context.Context) arbor.Status {
+					tick++
+					if tick == 1 {
+						return arbor.Running // Running on tick 1
+					}
+					return arbor.Success // Success on tick 2
+				},
+				arbor.WithHaltFunc(func() { child1Halted = true }),
+			),
+			arbor.NewAction("a2", func(ctx context.Context) arbor.Status {
+				return arbor.Running
+			}),
+		),
+	)
+
+	// Tick 1: a1=Running → reactive Running, running=0
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()))
+
+	// Tick 2: a1=Success, a2=Running → running switches from 0 to 1 → a1 halted
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()))
+	assert.True(t, child1Halted, "a1 should be halted when running child changes")
+}
+
+// --- ReactiveFallback ---
+
+func TestReactiveFallback_ReEvaluatesFromStart(t *testing.T) {
+	condTickCount := 0
+
+	tree := arbor.NewTree(
+		arbor.NewReactiveFallback("reactive",
+			arbor.NewCondition("check", func(ctx context.Context) bool {
+				condTickCount++
+				return false
+			}),
+			arbor.NewAction("fallback", func(ctx context.Context) arbor.Status {
+				return arbor.Running
+			}),
+		),
+	)
+
+	tree.Tick(context.Background())
+	tree.Tick(context.Background())
+
+	assert.Equal(t, 2, condTickCount, "condition should be re-evaluated every tick")
+}
+
+func TestReactiveFallback_HigherPriorityPreempts(t *testing.T) {
+	condResult := false
+	fallbackHalted := false
+
+	tree := arbor.NewTree(
+		arbor.NewReactiveFallback("reactive",
+			arbor.NewCondition("fast-path", func(ctx context.Context) bool {
+				return condResult
+			}),
+			arbor.NewAction("slow-path",
+				func(ctx context.Context) arbor.Status { return arbor.Running },
+				arbor.WithHaltFunc(func() { fallbackHalted = true }),
+			),
+		),
+	)
+
+	// Tick 1: fast-path fails, slow-path Running
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()))
+	assert.False(t, fallbackHalted)
+
+	// Fast-path now succeeds
+	condResult = true
+
+	// Tick 2: fast-path succeeds → slow-path halted → Success
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()))
+	assert.True(t, fallbackHalted, "slow-path should be halted when fast-path succeeds")
+}
+
+func TestReactiveFallback_AllFail(t *testing.T) {
+	tree := arbor.NewTree(
+		arbor.NewReactiveFallback("all-fail",
+			arbor.NewCondition("c1", func(ctx context.Context) bool { return false }),
+			arbor.NewCondition("c2", func(ctx context.Context) bool { return false }),
+		),
+	)
+
+	assert.Equal(t, arbor.Failure, tree.Tick(context.Background()))
+}
+
+func TestReactiveFallback_FirstSucceeds(t *testing.T) {
+	tree := arbor.NewTree(
+		arbor.NewReactiveFallback("first-ok",
+			arbor.NewCondition("check", func(ctx context.Context) bool { return true }),
+			arbor.NewAction("never", func(ctx context.Context) arbor.Status {
+				assert.Fail(t, "should not be reached")
+				return arbor.Success
+			}),
+		),
+	)
+
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()))
+}
+
+// --- Visualization ---
+
+func TestReactive_Visualization(t *testing.T) {
+	tree := arbor.NewTree(
+		arbor.NewReactiveSequence("guard",
+			arbor.NewCondition("ok", func(ctx context.Context) bool { return true }),
+			arbor.NewAction("work", func(ctx context.Context) arbor.Status { return arbor.Running }),
+		),
+	)
+
+	tree.Tick(context.Background())
+	output := arbor.SprintTree(tree)
+
+	assert.Contains(t, output, "ReactiveSequence: guard (Running)")
+	assert.Contains(t, output, "[✓] Condition: ok (Success)")
+	assert.Contains(t, output, "[~] Action: work (Running)")
+}

--- a/visualize.go
+++ b/visualize.go
@@ -37,6 +37,10 @@ func nodeType(n Node) string {
 		return "Fallback"
 	case *Parallel:
 		return "Parallel"
+	case *ReactiveSequence:
+		return "ReactiveSequence"
+	case *ReactiveFallback:
+		return "ReactiveFallback"
 	case *Inverter:
 		return "Inverter"
 	case *Repeater:


### PR DESCRIPTION
Changelog
======
- Implement `ReactiveSequence` — re-evaluates from child 0 every tick, halts previously Running child on condition change
- Implement `ReactiveFallback` — re-evaluates from child 0 every tick, halts lower-priority Running child when higher-priority succeeds
- Both implement `Haltable` for clean interruption
- Add reactive types to tree visualization

Closes #24

Testing
======
- `go test ./...` — all PASS
- 9 reactive-specific tests: re-evaluation, halt on condition change, preemption, visualization