### PR TITLE
feat: implement Subtree for modular tree composition

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -190,4 +190,57 @@ func main() {
 			return e.Status == arbor.Running
 		}),
 	)
+
+	// --- Scenario 6: Subtree with Blackboard mapping ---
+	fmt.Println("\n--- Scenario 6: Subtree (reusable assign module) ---")
+	agentIdle = true
+	batteryLevel = 80
+	assignAttempts = 0
+
+	// Reusable subtree: assigns a job to whatever "target" is in its Blackboard
+	assignSubtree := arbor.NewTree(
+		arbor.NewSequence("assign-flow",
+			arbor.NewAction("do-assign", func(ctx context.Context) arbor.Status {
+				bb := arbor.BlackboardFrom(ctx)
+				agent, _ := arbor.GetTyped[string](bb, "target")
+				job, _ := arbor.GetTyped[string](bb, "job")
+				fmt.Printf("  >> [subtree] Assigned %s to %s\n", job, agent)
+				bb.Set("result", "assigned")
+				return arbor.Success
+			}),
+			arbor.NewAction("do-notify", func(ctx context.Context) arbor.Status {
+				bb := arbor.BlackboardFrom(ctx)
+				agent, _ := arbor.GetTyped[string](bb, "target")
+				fmt.Printf("  >> [subtree] Notified %s\n", agent)
+				return arbor.Success
+			}),
+		),
+	)
+
+	mainTree := arbor.NewTree(
+		arbor.NewSequence("dispatch",
+			arbor.NewAction("find-agent", func(ctx context.Context) arbor.Status {
+				bb := arbor.BlackboardFrom(ctx)
+				bb.Set("selected_agent", "agent-3")
+				bb.Set("selected_job", "job-99")
+				fmt.Println("  >> Found best agent: agent-3")
+				return arbor.Success
+			}),
+			arbor.NewSubtree("assign-module", assignSubtree,
+				arbor.WithInputMapping("selected_agent", "target"),
+				arbor.WithInputMapping("selected_job", "job"),
+				arbor.WithOutputMapping("result", "assign_result"),
+			),
+			arbor.NewAction("verify", func(ctx context.Context) arbor.Status {
+				bb := arbor.BlackboardFrom(ctx)
+				result, _ := arbor.GetTyped[string](bb, "assign_result")
+				fmt.Printf("  >> Verify: assign_result=%s\n", result)
+				return arbor.Success
+			}),
+		),
+	)
+
+	fmt.Println("\n[Tick 1]")
+	mainTree.Tick(context.Background())
+	arbor.PrintTree(os.Stdout, mainTree)
 }

--- a/subtree.go
+++ b/subtree.go
@@ -1,0 +1,100 @@
+package arbor
+
+import "context"
+
+// SubtreeOption configures a Subtree node.
+type SubtreeOption func(*Subtree)
+
+// WithInputMapping maps a key from the parent Blackboard to the subtree Blackboard.
+// Before each tick, the value is copied from parentKey to subtreeKey.
+func WithInputMapping(parentKey, subtreeKey string) SubtreeOption {
+	return func(s *Subtree) {
+		s.inputMappings = append(s.inputMappings, keyMapping{parentKey, subtreeKey})
+	}
+}
+
+// WithOutputMapping maps a key from the subtree Blackboard to the parent Blackboard.
+// After each tick, the value is copied from subtreeKey to parentKey.
+func WithOutputMapping(subtreeKey, parentKey string) SubtreeOption {
+	return func(s *Subtree) {
+		s.outputMappings = append(s.outputMappings, keyMapping{subtreeKey, parentKey})
+	}
+}
+
+type keyMapping struct {
+	from string
+	to   string
+}
+
+// Subtree wraps a Tree as a node, enabling modular tree composition.
+// The inner tree has its own isolated Blackboard.
+// Data can be exchanged via input/output key mappings.
+type Subtree struct {
+	name           string
+	inner          *Tree
+	inputMappings  []keyMapping
+	outputMappings []keyMapping
+	lastStatus     *Status
+}
+
+// NewSubtree creates a new Subtree node wrapping the given tree.
+func NewSubtree(name string, inner *Tree, opts ...SubtreeOption) *Subtree {
+	s := &Subtree{
+		name:  name,
+		inner: inner,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// Tick copies input mappings, ticks the inner tree, then copies output mappings.
+func (s *Subtree) Tick(ctx context.Context) Status {
+	parentBB := BlackboardFrom(ctx)
+	innerBB := s.inner.Blackboard()
+
+	// Copy inputs: parent → subtree
+	if parentBB != nil {
+		for _, m := range s.inputMappings {
+			if v, ok := parentBB.Get(m.from); ok {
+				innerBB.Set(m.to, v)
+			}
+		}
+	}
+
+	status := s.inner.Tick(ctx)
+
+	// Copy outputs: subtree → parent
+	if parentBB != nil {
+		for _, m := range s.outputMappings {
+			if v, ok := innerBB.Get(m.from); ok {
+				parentBB.Set(m.to, v)
+			}
+		}
+	}
+
+	s.lastStatus = statusPtr(status)
+	return status
+}
+
+// Halt propagates halt to the inner tree's root node.
+func (s *Subtree) Halt() {
+	haltNode(s.inner.Root())
+	s.lastStatus = nil
+}
+
+// Children returns the inner tree's root node for visualization.
+func (s *Subtree) Children() []Node {
+	return []Node{s.inner.Root()}
+}
+
+// String returns the name of the subtree.
+func (s *Subtree) String() string {
+	return s.name
+}
+
+// LastStatus returns the last tick result (implements Stateful).
+func (s *Subtree) LastStatus() *Status {
+	return s.lastStatus
+}

--- a/subtree_test.go
+++ b/subtree_test.go
@@ -1,0 +1,199 @@
+package arbor_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	arbor "github.com/ToySin/go-arbor"
+)
+
+func TestSubtree_DelegatesTickToInnerTree(t *testing.T) {
+	executed := false
+	inner := arbor.NewTree(
+		arbor.NewAction("work", func(ctx context.Context) arbor.Status {
+			executed = true
+			return arbor.Success
+		}),
+	)
+
+	tree := arbor.NewTree(
+		arbor.NewSubtree("sub", inner),
+	)
+
+	status := tree.Tick(context.Background())
+
+	assert.Equal(t, arbor.Success, status)
+	assert.True(t, executed)
+}
+
+func TestSubtree_IsolatedBlackboard(t *testing.T) {
+	inner := arbor.NewTree(
+		arbor.NewAction("write", func(ctx context.Context) arbor.Status {
+			bb := arbor.BlackboardFrom(ctx)
+			bb.Set("inner_key", "inner_value")
+			return arbor.Success
+		}),
+	)
+
+	tree := arbor.NewTree(
+		arbor.NewSequence("seq",
+			arbor.NewSubtree("sub", inner),
+			arbor.NewAction("check", func(ctx context.Context) arbor.Status {
+				bb := arbor.BlackboardFrom(ctx)
+				// inner_key should NOT be visible in parent BB
+				if bb.Has("inner_key") {
+					return arbor.Failure
+				}
+				return arbor.Success
+			}),
+		),
+	)
+
+	status := tree.Tick(context.Background())
+
+	assert.Equal(t, arbor.Success, status)
+}
+
+func TestSubtree_InputMapping(t *testing.T) {
+	inner := arbor.NewTree(
+		arbor.NewAction("use-target", func(ctx context.Context) arbor.Status {
+			bb := arbor.BlackboardFrom(ctx)
+			target, ok := arbor.GetTyped[string](bb, "target")
+			if !ok || target != "agent-7" {
+				return arbor.Failure
+			}
+			return arbor.Success
+		}),
+	)
+
+	tree := arbor.NewTree(
+		arbor.NewSequence("seq",
+			arbor.NewAction("set-target", func(ctx context.Context) arbor.Status {
+				bb := arbor.BlackboardFrom(ctx)
+				bb.Set("parent_target", "agent-7")
+				return arbor.Success
+			}),
+			arbor.NewSubtree("sub", inner,
+				arbor.WithInputMapping("parent_target", "target"),
+			),
+		),
+	)
+
+	status := tree.Tick(context.Background())
+
+	assert.Equal(t, arbor.Success, status)
+}
+
+func TestSubtree_OutputMapping(t *testing.T) {
+	inner := arbor.NewTree(
+		arbor.NewAction("produce", func(ctx context.Context) arbor.Status {
+			bb := arbor.BlackboardFrom(ctx)
+			bb.Set("result", "done")
+			return arbor.Success
+		}),
+	)
+
+	tree := arbor.NewTree(
+		arbor.NewSequence("seq",
+			arbor.NewSubtree("sub", inner,
+				arbor.WithOutputMapping("result", "parent_result"),
+			),
+			arbor.NewAction("check", func(ctx context.Context) arbor.Status {
+				bb := arbor.BlackboardFrom(ctx)
+				v, ok := arbor.GetTyped[string](bb, "parent_result")
+				if !ok || v != "done" {
+					return arbor.Failure
+				}
+				return arbor.Success
+			}),
+		),
+	)
+
+	status := tree.Tick(context.Background())
+
+	assert.Equal(t, arbor.Success, status)
+}
+
+func TestSubtree_Running(t *testing.T) {
+	tickCount := 0
+	inner := arbor.NewTree(
+		arbor.NewAction("slow", func(ctx context.Context) arbor.Status {
+			tickCount++
+			if tickCount < 3 {
+				return arbor.Running
+			}
+			return arbor.Success
+		}),
+	)
+
+	tree := arbor.NewTree(
+		arbor.NewSubtree("sub", inner),
+	)
+
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()))
+	assert.Equal(t, arbor.Running, tree.Tick(context.Background()))
+	assert.Equal(t, arbor.Success, tree.Tick(context.Background()))
+}
+
+func TestSubtree_Halt(t *testing.T) {
+	halted := false
+	inner := arbor.NewTree(
+		arbor.NewAction("work",
+			func(ctx context.Context) arbor.Status { return arbor.Running },
+			arbor.WithHaltFunc(func() { halted = true }),
+		),
+	)
+
+	sub := arbor.NewSubtree("sub", inner)
+	tree := arbor.NewTree(sub)
+	tree.Tick(context.Background())
+
+	sub.Halt()
+
+	assert.True(t, halted)
+	assert.Nil(t, sub.LastStatus())
+}
+
+func TestSubtree_Reuse(t *testing.T) {
+	count := 0
+	inner := arbor.NewTree(
+		arbor.NewAction("work", func(ctx context.Context) arbor.Status {
+			count++
+			return arbor.Success
+		}),
+	)
+
+	tree := arbor.NewTree(
+		arbor.NewSequence("seq",
+			arbor.NewSubtree("first", inner),
+			arbor.NewSubtree("second", inner),
+		),
+	)
+
+	tree.Tick(context.Background())
+
+	assert.Equal(t, 2, count, "inner tree should be ticked twice (reused)")
+}
+
+func TestSubtree_Visualization(t *testing.T) {
+	inner := arbor.NewTree(
+		arbor.NewSequence("inner-seq",
+			arbor.NewAction("work", func(ctx context.Context) arbor.Status {
+				return arbor.Success
+			}),
+		),
+	)
+
+	tree := arbor.NewTree(
+		arbor.NewSubtree("my-subtree", inner),
+	)
+
+	tree.Tick(context.Background())
+	output := arbor.SprintTree(tree)
+
+	assert.Contains(t, output, "Subtree: my-subtree (Success)")
+	assert.Contains(t, output, "Sequence: inner-seq (Success)")
+	assert.Contains(t, output, "Action: work (Success)")
+}

--- a/visualize.go
+++ b/visualize.go
@@ -41,6 +41,8 @@ func nodeType(n Node) string {
 		return "ReactiveSequence"
 	case *ReactiveFallback:
 		return "ReactiveFallback"
+	case *Subtree:
+		return "Subtree"
 	case *Inverter:
 		return "Inverter"
 	case *Repeater:


### PR DESCRIPTION
Changelog
======
- Implement `Subtree` node — wraps a `*Tree` as a reusable node
- Isolated Blackboard per subtree by default
- `WithInputMapping(parentKey, subtreeKey)` — copy data from parent to subtree before tick
- `WithOutputMapping(subtreeKey, parentKey)` — copy data from subtree to parent after tick
- Halt propagation to inner tree root
- Visualization shows inner tree structure inline

Closes #25

Testing
======
- `go test ./...` — all PASS
- 8 subtree tests: delegation, Blackboard isolation, input/output mapping, Running, Halt, reuse, visualization