### PR TITLE
docs: rewrite README with usage-focused examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,77 +2,201 @@
 
 A generic Behavior Tree library for Go.
 
-Tick-based execution model following the standard BT formalism. Designed to be embedded in any Go application — from job dispatchers to robot controllers to game AI.
+Tick-based execution following the standard BT formalism. Designed for job dispatchers, robot controllers, game AI, and any application that needs structured decision-making.
 
-## Core Concepts
+## Install
 
-### Node Status
-
-Every node returns one of three statuses on each tick:
-
-- **Success** — node completed successfully
-- **Failure** — node failed
-- **Running** — node is still in progress, will resume on next tick
-
-### Node Types
-
-**Composite** — control flow with multiple children
-- **Sequence** — ticks children left-to-right, fails on first failure, succeeds when all succeed
-- **Fallback (Selector)** — ticks children left-to-right, succeeds on first success, fails when all fail
-- **Parallel** — ticks all children concurrently, configurable success/failure policy
-
-**Decorator** — wraps a single child, modifies behavior
-- **Inverter** — flips Success ↔ Failure
-- **Repeater** — re-ticks child N times or until failure
-- **Retry** — re-ticks child on failure, up to N attempts
-- **Timeout** — fails child if it stays Running beyond a duration
-
-**Leaf** — actual work
-- **Action** — executes logic, returns status
-- **Condition** — evaluates a predicate, returns Success or Failure
-
-### Blackboard
-
-A shared key-value store accessible by all nodes in a tree. Used to pass data between nodes without coupling them directly.
-
-### Tick Execution
-
-```go
-// Manual tick — caller controls when to tick
-status := tree.Tick(ctx)
-
-// Auto tick — library runs a tick loop at the given interval
-tree.Run(ctx, 100*time.Millisecond)
+```bash
+go get github.com/ToySin/go-arbor
 ```
 
-## Phases
+## Quick Start
 
-### Phase 1 — Core
+```go
+package main
 
-- Node interface + Status (Success, Failure, Running)
-- Composite nodes: Sequence, Fallback
-- Leaf nodes: Action, Condition
-- Tick-based execution with Running node re-entry
+import (
+    "context"
+    "fmt"
+    "os"
 
-### Phase 2 — Advanced Nodes + Visualization
+    arbor "github.com/ToySin/go-arbor"
+)
 
-- Parallel composite node
-- Decorator nodes: Inverter, Repeater, Retry, Timeout
-- Blackboard (shared context between nodes)
-- Tick runner (`tree.Run(ctx, interval)`)
-- Tree structure visualization with live node status
+func main() {
+    tree := arbor.NewTree(
+        arbor.NewFallback("root",
+            arbor.NewSequence("try-primary",
+                arbor.NewCondition("is-ready", func(ctx context.Context) bool {
+                    return true
+                }),
+                arbor.NewAction("do-work", func(ctx context.Context) arbor.Status {
+                    fmt.Println("working!")
+                    return arbor.Success
+                }),
+            ),
+            arbor.NewAction("fallback", func(ctx context.Context) arbor.Status {
+                fmt.Println("fallback plan")
+                return arbor.Success
+            }),
+        ),
+    )
 
-### Phase 3 — Builder & Configuration
+    tree.Tick(context.Background())
+    arbor.PrintTree(os.Stdout, tree)
+}
+```
 
-- Fluent tree builder API
-- YAML/JSON tree definition and loading
-- Tree structure validation at build time
+Output:
 
-### Phase 4 — Observability
+```
+working!
+[✓] Fallback: root (Success)
+├── [✓] Sequence: try-primary (Success)
+│   ├── [✓] Condition: is-ready (Success)
+│   └── [✓] Action: do-work (Success)
+└── [ ] Action: fallback (-)
+```
 
-- Per-tick logging and tracing
-- Per-node execution statistics
+## Node Types
+
+### Composite — control flow with multiple children
+
+| Node | Behavior |
+|------|----------|
+| `Sequence` | Ticks left-to-right. Fails on first failure. Succeeds when all succeed. |
+| `Fallback` | Ticks left-to-right. Succeeds on first success. Fails when all fail. |
+| `Parallel` | Ticks all children. Configurable success/failure threshold. |
+| `ReactiveSequence` | Like Sequence, but re-evaluates from child 0 every tick. Halts previously Running children. |
+| `ReactiveFallback` | Like Fallback, but re-evaluates from child 0 every tick. |
+
+### Decorator — wraps a single child
+
+| Node | Behavior |
+|------|----------|
+| `Inverter` | Flips Success ↔ Failure. Running passes through. |
+| `Repeater` | Ticks child N times. Fails immediately on child failure. |
+| `Retry` | Re-ticks child on failure, up to N attempts. |
+| `Timeout` | Fails if child stays Running beyond the given duration. |
+
+### Leaf — actual work
+
+| Node | Behavior |
+|------|----------|
+| `Action` | Executes a function, returns Success / Failure / Running. |
+| `Condition` | Evaluates a predicate, returns Success or Failure. Never Running. |
+
+### Subtree — modular composition
+
+Embed a tree as a node inside another tree, with isolated Blackboard and optional key mapping.
+
+```go
+innerTree := arbor.NewTree(arbor.NewAction("work", workFn))
+
+mainTree := arbor.NewTree(
+    arbor.NewSubtree("module", innerTree,
+        arbor.WithInputMapping("parent_key", "subtree_key"),
+        arbor.WithOutputMapping("subtree_result", "parent_result"),
+    ),
+)
+```
+
+## Blackboard
+
+Shared key-value store for passing data between nodes. Automatically injected into context on each tick.
+
+```go
+tree := arbor.NewTree(
+    arbor.NewSequence("pipeline",
+        arbor.NewAction("produce", func(ctx context.Context) arbor.Status {
+            bb := arbor.BlackboardFrom(ctx)
+            bb.Set("target", "agent-7")
+            return arbor.Success
+        }),
+        arbor.NewAction("consume", func(ctx context.Context) arbor.Status {
+            bb := arbor.BlackboardFrom(ctx)
+            target, ok := arbor.GetTyped[string](bb, "target")
+            if !ok {
+                return arbor.Failure
+            }
+            fmt.Println("assigned to", target)
+            return arbor.Success
+        }),
+    ),
+)
+```
+
+## Fluent Builder
+
+Build trees with a chainable API:
+
+```go
+tree := arbor.NewBuilder().
+    Sequence("dispatch").
+        Condition("is-ready", readyFn).
+        Retry("retry-assign", 3).
+            Action("assign", assignFn).
+        End().
+        Action("notify", notifyFn).
+    End().
+    MustBuild()
+```
+
+## Tick Execution
+
+```go
+// Manual — caller controls when to tick
+status := tree.Tick(ctx)
+
+// Auto — tick loop at a fixed interval
+tree.Run(ctx, 100*time.Millisecond,
+    arbor.WithTickCallback(func(e arbor.TickEvent) bool {
+        fmt.Printf("tick %d: %s\n", e.Tick, e.Status)
+        return e.Status == arbor.Running // continue while Running
+    }),
+)
+```
+
+## Halt
+
+Nodes can be interrupted while Running. Halt resets internal state and propagates down the tree.
+
+```go
+action := arbor.NewAction("work", workFn,
+    arbor.WithHaltFunc(func() {
+        fmt.Println("interrupted, cleaning up")
+    }),
+)
+```
+
+Reactive nodes (ReactiveSequence, ReactiveFallback) automatically halt previously Running children when re-evaluation changes the active branch.
+
+## Visualization
+
+```go
+tree.Tick(ctx)
+arbor.PrintTree(os.Stdout, tree)
+// or
+output := arbor.SprintTree(tree)
+```
+
+```
+[~] Sequence: dispatch (Running)
+├── [✓] Condition: agent-idle (Success)
+├── [~] Retry: retry-assign (Running)
+│   └── [✗] Action: assign-job (Failure)
+└── [ ] Action: notify (-)
+```
+
+## Status
+
+| Symbol | Status |
+|--------|--------|
+| `[✓]` | Success |
+| `[✗]` | Failure |
+| `[~]` | Running |
+| `[ ]` | Not yet ticked |
 
 ## License
 
-TBD
+MIT


### PR DESCRIPTION
Changelog
======
- Complete README rewrite focused on how to use the library
- Install instructions, quick start, all node types with tables
- Blackboard, fluent builder, tick execution, halt, visualization examples
- License set to MIT

Testing
======
- `go test ./...` — all PASS